### PR TITLE
Add editable text backend

### DIFF
--- a/components/HomePage.js
+++ b/components/HomePage.js
@@ -2,7 +2,7 @@ import { Button } from "../components/ui/button";
 import { Card, CardContent } from "../components/ui/card";
 import Image from "next/image";
 
-export default function HomePage() {
+export default function HomePage({ content }) {
   return (
     <div className="min-h-screen bg-white text-gray-900 font-sans">
       {/* Navigation Header */}
@@ -11,16 +11,15 @@ export default function HomePage() {
         <ul className="hidden md:flex gap-6 text-sm">
           <li><a href="/whatwedo" className="hover:underline">What We Do</a></li>
           <li><a href="#contact" className="hover:underline">Contact</a></li>
+          <li><a href="/login" className="hover:underline">Admin</a></li>
         </ul>
         <Button className="bg-[#00A6A6] hover:bg-[#008C8C] text-white px-4 py-2 text-sm">Book a Call</Button>
       </nav>
 
       <header className="max-w-4xl mx-auto text-center py-16 px-4">
-        <h1 className="text-4xl md:text-5xl font-bold mb-4 text-[#0D1B2A]">Sales-as-a-Service for the Vehicle Rental Industry</h1>
-        <p className="mt-4 text-lg md:text-xl text-gray-700">
-          Rouleur Co. helps vehicle hire businesses grow with expert outbound sales, lead nurturing, and strategy — without the cost of a full sales team.
-        </p>
-        <Button className="mt-6 text-lg px-8 py-4 bg-[#00A6A6] hover:bg-[#008C8C] text-white">Book a Discovery Call</Button>
+        <h1 className="text-4xl md:text-5xl font-bold mb-4 text-[#0D1B2A]">{content.hero.title}</h1>
+        <p className="mt-4 text-lg md:text-xl text-gray-700">{content.hero.subtitle}</p>
+        <Button className="mt-6 text-lg px-8 py-4 bg-[#00A6A6] hover:bg-[#008C8C] text-white">{content.hero.ctaText}</Button>
       </header>
 
       <section id="services" className="max-w-5xl mx-auto grid grid-cols-1 md:grid-cols-3 gap-8 px-6 mb-20">

--- a/data/content.json
+++ b/data/content.json
@@ -1,0 +1,7 @@
+{
+  "hero": {
+    "title": "Sales-as-a-Service for the Vehicle Rental Industry",
+    "subtitle": "Rouleur Co. helps vehicle hire businesses grow with expert outbound sales, lead nurturing, and strategy — without the cost of a full sales team.",
+    "ctaText": "Book a Discovery Call"
+  }
+}

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -1,0 +1,97 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+
+export default function Admin() {
+  const [content, setContent] = useState({ hero: { title: '', subtitle: '', ctaText: '' } });
+  const router = useRouter();
+
+  useEffect(() => {
+    fetch('/api/content')
+      .then(res => res.json())
+      .then(data => setContent(data));
+  }, []);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setContent(prev => ({
+      ...prev,
+      hero: { ...prev.hero, [name]: value },
+    }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    await fetch('/api/content', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(content),
+    });
+    alert('Content updated');
+  };
+
+  const handleLogout = async () => {
+    await fetch('/api/logout', { method: 'POST' });
+    router.push('/login');
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Admin</h1>
+      <form onSubmit={handleSubmit} className="grid gap-4 max-w-xl">
+        <label className="flex flex-col">
+          <span>Hero Title</span>
+          <input
+            type="text"
+            name="title"
+            value={content.hero.title}
+            onChange={handleChange}
+            className="border p-2"
+          />
+        </label>
+        <label className="flex flex-col">
+          <span>Hero Subtitle</span>
+          <textarea
+            name="subtitle"
+            value={content.hero.subtitle}
+            onChange={handleChange}
+            className="border p-2"
+          />
+        </label>
+        <label className="flex flex-col">
+          <span>CTA Text</span>
+          <input
+            type="text"
+            name="ctaText"
+            value={content.hero.ctaText}
+            onChange={handleChange}
+            className="border p-2"
+          />
+        </label>
+        <button type="submit" className="bg-blue-500 text-white p-2 rounded">
+          Save
+        </button>
+        <button
+          type="button"
+          onClick={handleLogout}
+          className="bg-gray-500 text-white p-2 rounded"
+        >
+          Log Out
+        </button>
+      </form>
+    </div>
+  );
+}
+
+export async function getServerSideProps({ req }) {
+  const cookies = {};
+  if (req.headers.cookie) {
+    req.headers.cookie.split(';').forEach(c => {
+      const [key, value] = c.trim().split('=');
+      cookies[key] = value;
+    });
+  }
+  if (cookies.auth !== '1') {
+    return { redirect: { destination: '/login', permanent: false } };
+  }
+  return { props: {} };
+}

--- a/pages/api/content.js
+++ b/pages/api/content.js
@@ -1,0 +1,35 @@
+import fs from 'fs';
+import path from 'path';
+
+const contentFile = path.join(process.cwd(), 'data', 'content.json');
+
+export default function handler(req, res) {
+  if (req.method === 'GET') {
+    try {
+      const data = JSON.parse(fs.readFileSync(contentFile, 'utf8'));
+      res.status(200).json(data);
+    } catch (err) {
+      res.status(500).json({ message: 'Failed to load content' });
+    }
+  } else if (req.method === 'POST') {
+    const cookies = {};
+    if (req.headers.cookie) {
+      req.headers.cookie.split(';').forEach(c => {
+        const [key, value] = c.trim().split('=');
+        cookies[key] = value;
+      });
+    }
+    if (cookies.auth !== '1') {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+    try {
+      fs.writeFileSync(contentFile, JSON.stringify(req.body, null, 2));
+      res.status(200).json({ message: 'Content updated' });
+    } catch (err) {
+      res.status(500).json({ message: 'Failed to save content' });
+    }
+  } else {
+    res.setHeader('Allow', ['GET', 'POST']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+}

--- a/pages/api/login.js
+++ b/pages/api/login.js
@@ -1,0 +1,14 @@
+export default function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+
+  const { username, password } = req.body;
+  if (username === 'admin' && password === 'admin') {
+    res.setHeader('Set-Cookie', 'auth=1; Path=/; HttpOnly');
+    res.status(200).json({ message: 'Logged in' });
+  } else {
+    res.status(401).json({ message: 'Invalid credentials' });
+  }
+}

--- a/pages/api/logout.js
+++ b/pages/api/logout.js
@@ -1,0 +1,8 @@
+export default function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+  res.setHeader('Set-Cookie', 'auth=; Path=/; Max-Age=0; HttpOnly');
+  res.status(200).json({ message: 'Logged out' });
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,13 @@
 import HomePage from '../components/HomePage';
-export default function Index() {
-  return <HomePage />;
+import fs from 'fs';
+import path from 'path';
+
+export async function getServerSideProps() {
+  const filePath = path.join(process.cwd(), 'data', 'content.json');
+  const content = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  return { props: { content } };
+}
+
+export default function Index({ content }) {
+  return <HomePage content={content} />;
 }

--- a/pages/login.js
+++ b/pages/login.js
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+import { Button } from '../components/ui/button';
+
+export default function Login() {
+  const router = useRouter();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    });
+    if (res.ok) {
+      router.push('/admin');
+    } else {
+      setError('Invalid credentials');
+    }
+  };
+
+  return (
+    <div className="p-4 max-w-sm mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Login</h1>
+      <form onSubmit={handleSubmit} className="grid gap-4">
+        <input
+          type="text"
+          placeholder="Username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          className="border p-2"
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="border p-2"
+        />
+        <Button type="submit" className="bg-blue-500 text-white">Log In</Button>
+        {error && <p className="text-red-600">{error}</p>}
+      </form>
+    </div>
+  );
+}

--- a/pages/whatwedo.js
+++ b/pages/whatwedo.js
@@ -14,6 +14,7 @@ export default function WhatWeDo() {
           <li><Link href="/" className="hover:underline">Home</Link></li>
           <li><Link href="/whatwedo" className="hover:underline">What We Do</Link></li>
           <li><a href="#contact" className="hover:underline">Contact</a></li>
+          <li><Link href="/login" className="hover:underline">Admin</Link></li>
         </ul>
         <Button className="bg-[#00A6A6] hover:bg-[#008C8C] text-white px-4 py-2 text-sm">Book a Call</Button>
       </nav>


### PR DESCRIPTION
## Summary
- allow text editing via admin page and content API
- load text from `data/content.json` so front page is editable
- show admin page with form to modify hero text
- add login system to secure admin area with username `admin`/password `admin`
- include admin link in site navigation

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6848330c42908333988e68792d15a16e