### PR TITLE
Use explicit Next.js versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "rouleurco-site",
       "version": "1.0.0",
       "dependencies": {
-        "next": "latest",
-        "react": "latest",
-        "react-dom": "latest"
+        "next": "15.3.3",
+        "react": "19.1.0",
+        "react-dom": "19.1.0"
       },
       "devDependencies": {
         "autoprefixer": "^10.4.21",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "latest",
-    "react": "latest",
-    "react-dom": "latest"
+    "next": "15.3.3",
+    "react": "19.1.0",
+    "react-dom": "19.1.0"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.21",


### PR DESCRIPTION
## Summary
- pin `next`, `react`, and `react-dom` versions in package.json
- update lockfile with `npm install`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68483689029c8333b5c11d702eba0c38