### PR TITLE
Add basic Jest test setup

### DIFF
--- a/components/ui/button.test.js
+++ b/components/ui/button.test.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Button } from './button';
+
+describe('Button', () => {
+  test('renders children', () => {
+    render(<Button>Click me</Button>);
+    expect(screen.getByText('Click me')).toBeTruthy();
+  });
+
+  test('applies provided className', () => {
+    const { container } = render(<Button className="test-class">Ok</Button>);
+    expect(container.firstChild.className.includes('test-class')).toBe(true);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test": "jest"
   },
   "dependencies": {
     "next": "latest",
@@ -14,6 +15,8 @@
   "devDependencies": {
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.4",
-    "tailwindcss": "^3.4.17"
+    "tailwindcss": "^3.4.17",
+    "@testing-library/react": "^14.2.1",
+    "jest": "^29.7.0"
   }
 }


### PR DESCRIPTION
## Summary
- add test script and dev dependencies for Jest and React Testing Library
- create a simple Button component test

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848309458008333b3bdb021e9c0c08a