### PR TITLE
Add case studies and new site pages

### DIFF
--- a/components/HomePage.js
+++ b/components/HomePage.js
@@ -4,7 +4,7 @@ export default function HomePage({ content }) {
   return (
     <main className="bg-white text-gray-900">
       {/* Hero Section */}
-      <section className="text-center py-24 px-6 bg-gradient-to-b from-white to-gray-100">
+      <section className="text-center py-24 px-6 bg-gray-900 text-white">
         <h1 className="text-4xl md:text-6xl font-bold mb-4">
           {content.hero.title}
         </h1>
@@ -12,10 +12,10 @@ export default function HomePage({ content }) {
           {content.hero.subtitle}
         </p>
         <div className="flex justify-center gap-4">
-          <Link href="/book" className="bg-black text-white px-6 py-3 rounded-md text-lg">
+          <Link href="/book" className="bg-white text-black px-6 py-3 rounded-md text-lg">
             Get Started
           </Link>
-          <Link href="/case-studies" className="underline text-lg">
+          <Link href="/case-studies" className="underline text-lg text-white">
             View Case Studies
           </Link>
         </div>

--- a/data/caseStudies.json
+++ b/data/caseStudies.json
@@ -1,0 +1,20 @@
+[
+  {
+    "slug": "tsp",
+    "title": "TSP Vehicle Solutions",
+    "summary": "+48% increase in converted leads in 90 days",
+    "body": "TSP partnered with Rouleur Co. to improve their sales pipeline. Our outreach and nurture campaigns helped convert more leads into long-term rentals."
+  },
+  {
+    "slug": "fleet",
+    "title": "Fleet Line Rentals",
+    "summary": "Doubled monthly bookings with targeted ads",
+    "body": "By managing PPC campaigns and refining landing pages, we were able to significantly increase Fleet Line's monthly bookings."
+  },
+  {
+    "slug": "rapid",
+    "title": "Rapid Hire",
+    "summary": "Improved retention by 35% through nurture sequences",
+    "body": "Automated email sequences kept Rapid Hire's clients engaged, leading to higher retention rates and repeat hires."
+  }
+]

--- a/pages/book.js
+++ b/pages/book.js
@@ -1,0 +1,12 @@
+import Meta from '../components/Meta';
+
+export default function Book() {
+  return (
+    <main className="max-w-4xl mx-auto py-16 px-6 text-center">
+      <Meta title="Book a Call" description="Schedule a discovery call with Rouleur Co." />
+      <h1 className="text-4xl font-bold mb-4">Book a Discovery Call</h1>
+      <p className="text-lg mb-8">We’d love to learn more about your business. Use the form below to book a time that works for you.</p>
+      <a href="https://calendly.com" className="bg-black text-white px-6 py-3 rounded inline-block">Book via Calendly</a>
+    </main>
+  );
+}

--- a/pages/case-studies/[slug].js
+++ b/pages/case-studies/[slug].js
@@ -1,0 +1,27 @@
+import fs from 'fs';
+import path from 'path';
+import Meta from '../../components/Meta';
+
+export async function getStaticPaths() {
+  const filePath = path.join(process.cwd(), 'data', 'caseStudies.json');
+  const studies = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  const paths = studies.map((s) => ({ params: { slug: s.slug } }));
+  return { paths, fallback: false };
+}
+
+export async function getStaticProps({ params }) {
+  const filePath = path.join(process.cwd(), 'data', 'caseStudies.json');
+  const studies = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  const study = studies.find((s) => s.slug === params.slug);
+  return { props: { study } };
+}
+
+export default function CaseStudy({ study }) {
+  return (
+    <main className="max-w-3xl mx-auto py-16 px-6">
+      <Meta title={study.title} description={study.summary} />
+      <h1 className="text-4xl font-bold mb-4">{study.title}</h1>
+      <p className="mb-6 text-gray-700">{study.body}</p>
+    </main>
+  );
+}

--- a/pages/case-studies/index.js
+++ b/pages/case-studies/index.js
@@ -1,0 +1,28 @@
+import fs from 'fs';
+import path from 'path';
+import Link from 'next/link';
+import Meta from '../../components/Meta';
+
+export async function getStaticProps() {
+  const filePath = path.join(process.cwd(), 'data', 'caseStudies.json');
+  const studies = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  return { props: { studies } };
+}
+
+export default function CaseStudies({ studies }) {
+  return (
+    <main className="max-w-5xl mx-auto py-16 px-6">
+      <Meta title="Case Studies" description="Success stories from our clients" />
+      <h1 className="text-4xl font-bold mb-8 text-center">Case Studies</h1>
+      <div className="space-y-8">
+        {studies.map((study) => (
+          <div key={study.slug} className="p-6 bg-white shadow rounded">
+            <h2 className="text-2xl font-semibold mb-2">{study.title}</h2>
+            <p className="text-gray-700 mb-2">{study.summary}</p>
+            <Link href={`/case-studies/${study.slug}`} className="text-blue-600 underline">Read More →</Link>
+          </div>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -1,0 +1,17 @@
+import Meta from '../components/Meta';
+
+export default function Contact() {
+  return (
+    <main className="max-w-4xl mx-auto py-16 px-6">
+      <Meta title="Contact" description="Get in touch with Rouleur Co." />
+      <h1 className="text-4xl font-bold mb-4 text-center">Contact Us</h1>
+      <p className="text-lg mb-8 text-center">Send us a message and we’ll get back to you soon.</p>
+      <form action="https://formspree.io/f/your-form-id" method="POST" className="space-y-4 max-w-md mx-auto">
+        <input type="text" name="name" placeholder="Name" className="w-full border p-2" required />
+        <input type="email" name="email" placeholder="Email" className="w-full border p-2" required />
+        <textarea name="message" placeholder="Message" className="w-full border p-2" rows="5" required></textarea>
+        <button type="submit" className="bg-black text-white px-4 py-2 rounded">Send</button>
+      </form>
+    </main>
+  );
+}

--- a/pages/privacy.js
+++ b/pages/privacy.js
@@ -1,0 +1,11 @@
+import Meta from '../components/Meta';
+
+export default function Privacy() {
+  return (
+    <main className="max-w-4xl mx-auto py-16 px-6">
+      <Meta title="Privacy Policy" description="Rouleur Co. privacy policy" />
+      <h1 className="text-4xl font-bold mb-4">Privacy Policy</h1>
+      <p className="mb-2">This is a placeholder privacy policy.</p>
+    </main>
+  );
+}

--- a/pages/services.js
+++ b/pages/services.js
@@ -4,14 +4,14 @@ import { Button } from "../components/ui/button";
 import Image from "next/image";
 import Meta from "../components/Meta";
 
-export default function WhatWeDo() {
+export default function Services() {
   return (
     <div className="min-h-screen bg-white text-gray-900 font-sans">
-      <Meta title="What We Do" description="Discover our services for the vehicle rental industry." />
+      <Meta title="Services" description="Discover our services for the vehicle rental industry." />
 
       {/* Header */}
       <header className="max-w-4xl mx-auto text-center py-16 px-4">
-        <h1 className="text-4xl md:text-5xl font-bold mb-4 text-[#0D1B2A]">What We Do</h1>
+        <h1 className="text-4xl md:text-5xl font-bold mb-4 text-[#0D1B2A]">Services</h1>
         <p className="mt-4 text-lg md:text-xl text-gray-700">
           We help vehicle rental businesses scale faster with outsourced sales, proven systems, and dedicated support.
         </p>

--- a/pages/terms.js
+++ b/pages/terms.js
@@ -1,0 +1,11 @@
+import Meta from '../components/Meta';
+
+export default function Terms() {
+  return (
+    <main className="max-w-4xl mx-auto py-16 px-6">
+      <Meta title="Terms of Use" description="Rouleur Co. terms of use" />
+      <h1 className="text-4xl font-bold mb-4">Terms of Use</h1>
+      <p className="mb-2">This is a placeholder terms of use page.</p>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add placeholder pages so header and footer links work
- create case studies listing and individual pages
- load case study data from JSON
- rename `whatwedo` page to `services`
- make hero match footer style

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684955e398d083339add5f5181b5a4ef