### PR TITLE
Add canonical and og:image tags

### DIFF
--- a/components/Meta.js
+++ b/components/Meta.js
@@ -1,6 +1,12 @@
 import Head from 'next/head';
 
-export default function Meta({ title = 'Rouleur Co.', description = 'Rouleur Co. helps vehicle hire businesses grow with outsourced sales.' }) {
+export default function Meta({
+  title = 'Rouleur Co.',
+  description =
+    'Rouleur Co. helps vehicle hire businesses grow with outsourced sales.',
+  canonical,
+  image,
+}) {
   const pageTitle = title ? `${title} | Rouleur Co.` : 'Rouleur Co.';
   return (
     <Head>
@@ -9,6 +15,8 @@ export default function Meta({ title = 'Rouleur Co.', description = 'Rouleur Co.
       <meta name="viewport" content="width=device-width, initial-scale=1" />
       <meta property="og:title" content={pageTitle} />
       <meta property="og:description" content={description} />
+      {canonical && <link rel="canonical" href={canonical} />}
+      {image && <meta property="og:image" content={image} />}
     </Head>
   );
 }

--- a/pages/about.js
+++ b/pages/about.js
@@ -5,7 +5,12 @@ import Meta from "../components/Meta";
 export default function About() {
   return (
     <div className="min-h-screen bg-white text-gray-900 font-sans">
-      <Meta title="About" description="Learn more about Rouleur Co." />
+      <Meta
+        title="About"
+        description="Learn more about Rouleur Co."
+        canonical="https://www.rouleurco.com/about"
+        image="/images/sales-leadership.png"
+      />
 
       <header className="max-w-4xl mx-auto text-center py-16 px-4">
         <h1 className="text-4xl md:text-5xl font-bold mb-4 text-[#0D1B2A]">About Rouleur Co.</h1>

--- a/pages/book.js
+++ b/pages/book.js
@@ -3,7 +3,12 @@ import Meta from '../components/Meta';
 export default function Book() {
   return (
     <main className="max-w-4xl mx-auto py-16 px-6 text-center">
-      <Meta title="Book a Call" description="Schedule a discovery call with Rouleur Co." />
+      <Meta
+        title="Book a Call"
+        description="Schedule a discovery call with Rouleur Co."
+        canonical="https://www.rouleurco.com/book"
+        image="/images/sales-leadership.png"
+      />
       <h1 className="text-4xl font-bold mb-4">Book a Discovery Call</h1>
       <p className="text-lg mb-8">We’d love to learn more about your business. Use the form below to book a time that works for you.</p>
       <a href="https://calendly.com" className="bg-black text-white px-6 py-3 rounded inline-block">Book via Calendly</a>

--- a/pages/case-studies/[slug].js
+++ b/pages/case-studies/[slug].js
@@ -19,7 +19,12 @@ export async function getStaticProps({ params }) {
 export default function CaseStudy({ study }) {
   return (
     <main className="max-w-3xl mx-auto py-16 px-6">
-      <Meta title={study.title} description={study.summary} />
+      <Meta
+        title={study.title}
+        description={study.summary}
+        canonical={`https://www.rouleurco.com/case-studies/${study.slug}`}
+        image="/images/sales-leadership.png"
+      />
       <h1 className="text-4xl font-bold mb-4">{study.title}</h1>
       <p className="mb-6 text-gray-700">{study.body}</p>
     </main>

--- a/pages/case-studies/index.js
+++ b/pages/case-studies/index.js
@@ -12,7 +12,12 @@ export async function getStaticProps() {
 export default function CaseStudies({ studies }) {
   return (
     <main className="max-w-5xl mx-auto py-16 px-6">
-      <Meta title="Case Studies" description="Success stories from our clients" />
+      <Meta
+        title="Case Studies"
+        description="Success stories from our clients"
+        canonical="https://www.rouleurco.com/case-studies"
+        image="/images/sales-leadership.png"
+      />
       <h1 className="text-4xl font-bold mb-8 text-center">Case Studies</h1>
       <div className="space-y-8">
         {studies.map((study) => (

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -3,7 +3,12 @@ import Meta from '../components/Meta';
 export default function Contact() {
   return (
     <main className="max-w-4xl mx-auto py-16 px-6">
-      <Meta title="Contact" description="Get in touch with Rouleur Co." />
+      <Meta
+        title="Contact"
+        description="Get in touch with Rouleur Co."
+        canonical="https://www.rouleurco.com/contact"
+        image="/images/sales-leadership.png"
+      />
       <h1 className="text-4xl font-bold mb-4 text-center">Contact Us</h1>
       <p className="text-lg mb-8 text-center">Send us a message and we’ll get back to you soon.</p>
       <form action="https://formspree.io/f/your-form-id" method="POST" className="space-y-4 max-w-md mx-auto">

--- a/pages/index.js
+++ b/pages/index.js
@@ -15,6 +15,8 @@ export default function Index({ content }) {
       <Meta
         title="Home"
         description="Rouleur Co. helps vehicle hire businesses grow with expert outbound sales, lead nurturing and strategy."
+        canonical="https://www.rouleurco.com/"
+        image="/images/sales-leadership.png"
       />
       <HomePage content={content} />
     </>

--- a/pages/privacy.js
+++ b/pages/privacy.js
@@ -3,7 +3,12 @@ import Meta from '../components/Meta';
 export default function Privacy() {
   return (
     <main className="max-w-4xl mx-auto py-16 px-6">
-      <Meta title="Privacy Policy" description="Rouleur Co. privacy policy" />
+      <Meta
+        title="Privacy Policy"
+        description="Rouleur Co. privacy policy"
+        canonical="https://www.rouleurco.com/privacy"
+        image="/images/sales-leadership.png"
+      />
       <h1 className="text-4xl font-bold mb-4">Privacy Policy</h1>
       <p className="mb-2">This is a placeholder privacy policy.</p>
     </main>

--- a/pages/services.js
+++ b/pages/services.js
@@ -7,7 +7,12 @@ import Meta from "../components/Meta";
 export default function Services() {
   return (
     <div className="min-h-screen bg-white text-gray-900 font-sans">
-      <Meta title="Services" description="Discover our services for the vehicle rental industry." />
+      <Meta
+        title="Services"
+        description="Discover our services for the vehicle rental industry."
+        canonical="https://www.rouleurco.com/services"
+        image="/images/sales-leadership.png"
+      />
 
       {/* Header */}
       <header className="max-w-4xl mx-auto text-center py-16 px-4">

--- a/pages/terms.js
+++ b/pages/terms.js
@@ -3,7 +3,12 @@ import Meta from '../components/Meta';
 export default function Terms() {
   return (
     <main className="max-w-4xl mx-auto py-16 px-6">
-      <Meta title="Terms of Use" description="Rouleur Co. terms of use" />
+      <Meta
+        title="Terms of Use"
+        description="Rouleur Co. terms of use"
+        canonical="https://www.rouleurco.com/terms"
+        image="/images/sales-leadership.png"
+      />
       <h1 className="text-4xl font-bold mb-4">Terms of Use</h1>
       <p className="mb-2">This is a placeholder terms of use page.</p>
     </main>


### PR DESCRIPTION
## Summary
- support optional `canonical` and `image` props in `Meta`
- provide canonical URLs and images for each page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68495bb57b88833384a09e6a786db272