### PR TITLE
Growth-frame re-messaging: stealth phase, register-interest, parked lead-gen/pricing, +2 feature pages

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -38,7 +38,7 @@ const audiences = [
     title: "Commercial Vehicle Hire",
     body: "Longer-term hire, larger vehicles, business accounts. More complex enquiries that need structured management.",
     bullets: [
-      "Contract hire pipeline management",
+      "Long-term hire pipeline management",
       "Document collection for longer-term hires",
       "Account management for repeat business customers",
     ],
@@ -76,7 +76,7 @@ const values = [
   },
   {
     title: "Built with operators, not for them",
-    body: "Founding operators aren't just early customers — they're co-builders. Their feedback directly shapes the product. We're building RouleurCo alongside the people who use it.",
+    body: "The operators we build alongside aren't just early customers — they're co-builders. Their feedback directly shapes the product. We're building RouleurCo alongside the people who use it.",
   },
 ];
 
@@ -207,10 +207,10 @@ export default function AboutPage() {
       </section>
 
       <CtaBanner
-        heading="Built for operators like you."
-        subtext="Join the founding group of rental operators helping shape RouleurCo from the ground up."
-        primary={{ label: "Register as a Founding Operator", href: "/contact#founding" }}
-        secondary={{ label: "View Pricing", href: "/pricing" }}
+        heading="Built for operators who want to grow."
+        subtext="RouleurCo runs the commercial side of your hire desk — so you win more of the right hires and the fleet earns year-round."
+        primary={{ label: "Register your interest", href: "/register-interest" }}
+        secondary={{ label: "Take the Growth Check", href: "/growth-check" }}
       />
     </>
   );

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -274,9 +274,9 @@ export default function ComparePage() {
         eyebrow="The Decision"
         heading="The question isn't whether to change. It's how long to wait."
         subtext="Every hire that goes uncontacted after a quote, every missed call with no response, every document chased manually — that's time and revenue that a structured process would have recovered."
-        primary={{ label: "Register as a Founding Operator", href: "/contact#founding" }}
+        primary={{ label: "Register your interest", href: "/register-interest" }}
         secondary={{ label: "Explore All Features →", href: "/features" }}
-        note="One-time setup fee of £500. Founding operators: 6-month minimum. Standard: 12-month minimum."
+        note="No commitment — just a conversation about whether it fits how your hire desk runs."
       />
 
       <Script

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -11,33 +11,40 @@ import { GhlIframe } from "@/components/forms/GhlIframe";
 import { FadeUp } from "@/components/motion/FadeUp";
 
 export const metadata: Metadata = buildMetadata({
-  title: "Get in Touch — Register as a Founding Operator",
+  title: "Get in Touch",
   description:
-    "Register your interest in RouleurCo's founding operator programme. Limited to the first 10 independent vehicle rental companies.",
+    "Get in touch with RouleurCo, or register your interest. We'll get back to you within two business days — no hard sell, just a conversation about how your hire desk runs.",
   path: "/contact",
 });
 
 const faqs: FAQItem[] = [
   {
-    question: "Do I need to commit to anything by registering?",
+    question: "Do I need to commit to anything by getting in touch?",
     answer:
-      "No. Registering your interest is completely free and puts you in the conversation about a founding operator spot. There's no commitment until you decide to proceed.",
+      "No. Getting in touch is free and just starts a conversation. There's nothing to sign and nothing to pay.",
   },
   {
-    question: "What happens after I register?",
+    question: "What happens after I get in touch?",
     answer:
-      "We'll contact you within 24 hours to have a short conversation about your business and what you're looking for. We'll walk you through the platform and the founding operator pricing. Then it's your call.",
+      "We'll come back to you within two business days for a short conversation about your hire desk and what you're looking for. We'll walk you through how RouleurCo works. Then it's your call.",
   },
   {
     question: "Is the platform available now?",
     answer:
-      "RouleurCo is currently in development with early operators. Founding operators get access as part of the early build process — you'll be onboarded as the platform is being finalised, not after a long wait.",
+      "RouleurCo is in a quiet build phase, working with a small group of operators. Get in touch and we'll show you where things are and give you an honest read on whether it's a fit.",
   },
   {
     question: "What if I'm not sure it's right for me?",
     answer:
-      "Register anyway and have the conversation. We'd rather you understand exactly what RouleurCo does and decide it's not right for you now than miss out on the founding pricing because you were unsure. There's no pressure.",
+      "Get in touch anyway. We'd rather show you exactly what RouleurCo does and have you decide it's not right for you now than have you wonder. There's no pressure.",
   },
+];
+
+const whatToExpect = [
+  "A reply within two business days",
+  "A short, no-pressure conversation",
+  "A walk-through of how it works",
+  "An honest read on whether it's a fit",
 ];
 
 export default function ContactPage() {
@@ -45,22 +52,22 @@ export default function ContactPage() {
     <>
       <PageHero
         crumbs={[{ label: "Home", href: "/" }, { label: "Contact" }]}
-        eyebrow="Get in Touch"
-        heading="Register your interest or ask us anything."
-        lead="Whether you want to secure a founding operator spot or just want to know more — we'll get back to you within 24 hours."
+        eyebrow="Get in touch"
+        heading="Get in touch — or register your interest."
+        lead="Want to see whether RouleurCo fits how your hire desk runs, or just have a question? Drop us a line and we'll get back to you within two business days."
       />
 
-      <section id="founding" className="bg-white py-20 sm:py-24">
+      <section id="contact-form" className="bg-white py-20 sm:py-24">
         <div className="container-rc">
           <div className="grid gap-16 lg:grid-cols-[1.3fr_1fr] lg:gap-16 items-start">
             <FadeUp>
               <div className="rounded-card border border-brand-mid bg-brand-lightbg p-8 sm:p-10">
-                <Eyebrow>Founding Operator Registration</Eyebrow>
+                <Eyebrow>Send us a message</Eyebrow>
                 <h2 className="mt-4 font-display text-2xl sm:text-3xl font-bold text-brand-navy">
-                  Register Your Interest
+                  Tell us about your hire desk
                 </h2>
                 <p className="mt-2 text-brand-text-2">
-                  Fill in your details below and we&apos;ll be in touch within 24 hours to discuss securing your founding operator spot.
+                  Fill in your details below and we&apos;ll be in touch within two business days. No hard sell — just a conversation.
                 </p>
                 <div className="mt-8">
                   <GhlIframe formId="z32IZHrmlAUbbSA7f8To" />
@@ -72,26 +79,15 @@ export default function ContactPage() {
               <FadeUp delay={0.1}>
                 <div className="rounded-card border border-white/10 bg-brand-navy text-white p-8 shadow-xl">
                   <h3 className="font-display text-xl font-bold">
-                    Founding Operator Programme
+                    What to expect
                   </h3>
-                  <div className="mt-5 flex flex-col">
-                    <PriceRow label="Founding price" value={<><strong>£250</strong><span className="text-sm font-medium text-white/45">/month</span></>} primary />
-                    <PriceRow label="Standard price" value={<span className="line-through text-white/35 text-sm">£350/month</span>} />
-                    <PriceRow label="One-time setup fee" value="£500" />
-                  </div>
-                  <p className="mt-5 text-sm text-white/60 leading-relaxed">
-                    The first 10 rental companies to join get their rate locked at £250/month permanently. Once those spots are gone, standard pricing applies.
+                  <p className="mt-3 text-sm text-white/60 leading-relaxed">
+                    We&apos;re in a quiet build phase, working with a small group of operators. Getting in touch just puts you in the conversation.
                   </p>
                   <CheckList
                     className="mt-6"
                     variant="white"
-                    items={[
-                      "Early platform access",
-                      "Founding operator pricing — locked in for life",
-                      "Influence over product features and roadmap",
-                      "Personal onboarding support",
-                      "Priority support line",
-                    ]}
+                    items={whatToExpect}
                   />
                 </div>
               </FadeUp>
@@ -103,7 +99,7 @@ export default function ContactPage() {
                     aria-hidden="true"
                   />
                   <p className="text-sm text-brand-navy">
-                    We typically respond within <strong>24 hours</strong> on business days.
+                    We typically respond within <strong>two business days</strong>.
                   </p>
                 </div>
               </FadeUp>
@@ -115,7 +111,7 @@ export default function ContactPage() {
       <section className="bg-brand-lightbg py-20 sm:py-24">
         <div className="container-rc max-w-3xl">
           <SectionHeader
-            eyebrow="Before You Register"
+            eyebrow="Before you get in touch"
             heading="Quick answers."
           />
           <div className="mt-12">
@@ -131,30 +127,5 @@ export default function ContactPage() {
         dangerouslySetInnerHTML={{ __html: buildFAQSchema(faqs) }}
       />
     </>
-  );
-}
-
-function PriceRow({
-  label,
-  value,
-  primary,
-}: {
-  label: string;
-  value: React.ReactNode;
-  primary?: boolean;
-}) {
-  return (
-    <div className="flex items-center justify-between py-3 border-b border-white/10 last:border-0">
-      <span className="text-sm text-white/55">{label}</span>
-      <span
-        className={
-          primary
-            ? "font-display text-2xl font-bold text-white"
-            : "font-display font-bold text-white/70"
-        }
-      >
-        {value}
-      </span>
-    </div>
   );
 }

--- a/app/features/ai-agent/page.tsx
+++ b/app/features/ai-agent/page.tsx
@@ -71,7 +71,7 @@ export default function AiAgentPage() {
         ]}
         eyebrow="Add-On Feature"
         heading="Your hire desk can't be available 24 hours a day. Your AI Agent can."
-        lead="Trained on your rental business. Answers questions, qualifies visitors, captures enquiries — and sends them straight into your pipeline, ready for your team to pick up."
+        lead="Win more of the right hires by being there when customers are. Trained on your rental business, it answers questions, qualifies visitors, and captures enquiries — sending them straight into your pipeline, ready for your team to pick up and turn into hires that grow the business."
         badge={{ tone: "amber", label: "Add-on" }}
       />
 
@@ -300,7 +300,7 @@ export default function AiAgentPage() {
                 <div className="flex items-center justify-between mb-5">
                   <div>
                     <div className="font-display text-sm font-bold text-brand-navy">Availability</div>
-                    <div className="text-xs text-brand-muted">Founding Operator &amp; Standard Plans</div>
+                    <div className="text-xs text-brand-muted">Available on every plan</div>
                   </div>
                   <Badge tone="blue">Add-On</Badge>
                 </div>
@@ -332,8 +332,8 @@ export default function AiAgentPage() {
       <CtaBanner
         heading="Your website should be capturing enquiries at midnight, not just at 9am."
         subtext="The AI Agent is an add-on to any RouleurCo plan. Includes knowledge base setup, eligibility configuration, and multi-channel deployment."
-        primary={{ label: "Add the AI Agent", href: "/contact#founding" }}
-        secondary={{ label: "See All Features", href: "/features" }}
+        primary={{ label: "Register your interest", href: "/register-interest" }}
+        secondary={{ label: "See all features", href: "/features" }}
       />
 
       <Script

--- a/app/features/apps/page.tsx
+++ b/app/features/apps/page.tsx
@@ -83,7 +83,7 @@ export default function AppsPage() {
         ]}
         eyebrow="Mobile & Desktop"
         heading="Your hire desk in your pocket. And on your desk. At the same time."
-        lead="Whether you're on the yard, at a customer site, or in the office — the RouleurCo app keeps your pipeline, conversations, and team tasks in sync. One system. Every device."
+        lead="Win more of the right hires — especially the long-term hires that steady your year — by never letting one slip. Whether you're on the yard, at a customer site, or in the office, the RouleurCo app keeps your pipeline, conversations, and team tasks in sync. One system. Every device."
       />
 
       {/* PROBLEM */}
@@ -244,8 +244,8 @@ export default function AppsPage() {
       <CtaBanner
         heading="Run the hire desk from anywhere."
         subtext="iOS, Android, Mac and Windows — full pipeline access, every message, every task. Your team works from one live system, on every device."
-        primary={{ label: "Register as a Founding Operator", href: "/contact#founding" }}
-        secondary={{ label: "View Pricing", href: "/pricing" }}
+        primary={{ label: "Register your interest", href: "/register-interest" }}
+        secondary={{ label: "See all features", href: "/features" }}
       />
 
       <Script

--- a/app/features/enquiry-sources/page.tsx
+++ b/app/features/enquiry-sources/page.tsx
@@ -1,0 +1,229 @@
+import type { Metadata } from "next";
+import Script from "next/script";
+import Link from "next/link";
+import { buildMetadata, SITE_URL } from "@/lib/metadata";
+import { buildSoftwareApplicationSchema } from "@/lib/faqSchema";
+import { PageHero } from "@/components/sections/PageHero";
+import { CtaBanner } from "@/components/sections/CtaBanner";
+import { SectionHeader } from "@/components/ui/SectionHeader";
+import { CheckList } from "@/components/ui/CheckList";
+import { Eyebrow } from "@/components/ui/Eyebrow";
+import { Badge } from "@/components/ui/Badge";
+import { FadeUp } from "@/components/motion/FadeUp";
+import { StaggerChildren, StaggerItem } from "@/components/motion/StaggerChildren";
+
+export const metadata: Metadata = buildMetadata({
+  title: "Enquiry Source Tracking — Know Where Your Hires Come From",
+  description:
+    "RouleurCo tags every enquiry with its source — Google, Facebook, website, phone — so you can see which channels bring hires, not just clicks, and put your effort where it pays.",
+  path: "/features/enquiry-sources",
+});
+
+const capabilities = [
+  {
+    title: "Every enquiry, tagged at the source",
+    body: "Google, Facebook, your website, the phone, a walk-in — each one logged against where it came from, automatically.",
+    badge: "Automatic",
+    tone: "blue" as const,
+  },
+  {
+    title: "See what's actually working",
+    body: "Which channels bring enquiries, which bring hires, and which quietly do nothing. Plenty of channels look busy and rarely convert — telling the difference is the whole point.",
+    badge: "Enquiries vs hires",
+    tone: "blue" as const,
+  },
+  {
+    title: "Spend your effort where it pays",
+    body: "If your Google Business Profile brings your best long-term hires, that's where to focus. If a channel's just noise, stop feeding it. You can only make that call if you can see it.",
+    badge: "Grow what works",
+    tone: "blue" as const,
+  },
+  {
+    title: "Built for a lean desk",
+    body: "No spreadsheets, no manual tallying — the picture builds itself as enquiries come in.",
+    badge: "Zero admin",
+    tone: "amber" as const,
+  },
+];
+
+const cantAnswer = [
+  "Which channel brings the most enquiries?",
+  "Which channel brings the most hires?",
+  "Which channel just looks busy?",
+  "Where do your best long-term hires come from?",
+];
+
+const inclusions = [
+  "Source captured on every enquiry, automatically",
+  "Enquiry volume and hire conversion by channel",
+  "Spot the channels quietly winning your long-term work",
+  "A live picture that builds itself — no manual tallying",
+];
+
+export default function EnquirySourcesPage() {
+  return (
+    <>
+      <PageHero
+        crumbs={[
+          { label: "Home", href: "/" },
+          { label: "Features", href: "/features" },
+          { label: "Enquiry Source Tracking" },
+        ]}
+        eyebrow="Feature Deep Dive"
+        heading="Know where your hires actually come from"
+        lead="Stop guessing which channel brings the work. RouleurCo tags every enquiry with its source — so you can see what's converting and put your effort where it pays."
+      />
+
+      {/* THE PROBLEM */}
+      <section className="bg-white py-20 sm:py-24">
+        <div className="container-rc">
+          <div className="grid gap-12 lg:grid-cols-2 lg:gap-16 items-center">
+            <FadeUp>
+              <Eyebrow>The Problem</Eyebrow>
+              <h2 className="mt-4 font-display text-3xl sm:text-4xl font-bold text-brand-navy leading-[1.15] text-balance">
+                You can&apos;t grow a channel you can&apos;t see.
+              </h2>
+              <div className="mt-6 flex flex-col gap-4 text-brand-text-2 leading-relaxed">
+                <p>
+                  Most operators have a rough feel for where their work comes from — but no numbers. So the marketing spend is a guess, the busy-looking channels get the credit, and the ones quietly bringing the best hires go unnoticed.
+                </p>
+                <p>
+                  The trouble is, a channel that brings lots of enquiries isn&apos;t always the one that brings hires. Without the source on every enquiry, you can&apos;t tell the difference — and you can&apos;t put your effort where it actually pays.
+                </p>
+              </div>
+            </FadeUp>
+
+            <FadeUp delay={0.1}>
+              <div className="rounded-card border border-brand-mid bg-brand-lightbg p-8">
+                <div className="font-display text-xs font-bold uppercase tracking-[0.08em] text-brand-muted">
+                  Questions most hire desks can&apos;t answer
+                </div>
+                <ul className="mt-5 flex flex-col gap-3">
+                  {cantAnswer.map((q) => (
+                    <li key={q} className="flex gap-3 items-start text-sm text-brand-text-2">
+                      <span className="mt-0.5 inline-flex size-5 shrink-0 items-center justify-center rounded-full bg-brand-amber/15 text-brand-amber text-xs font-bold">
+                        ?
+                      </span>
+                      <span>{q}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </FadeUp>
+          </div>
+        </div>
+      </section>
+
+      {/* CAPABILITIES */}
+      <section className="bg-brand-lightbg py-20 sm:py-24">
+        <div className="container-rc">
+          <SectionHeader
+            eyebrow="What It Does"
+            heading="Turn a hunch into a number."
+            lead="Every enquiry carries its source, so the picture of what's working builds itself — no spreadsheets required."
+          />
+          <StaggerChildren className="mt-12 grid gap-5 md:grid-cols-2">
+            {capabilities.map((c) => (
+              <StaggerItem key={c.title}>
+                <div className="h-full rounded-card border border-brand-mid bg-white p-7">
+                  <h3 className="font-display text-lg font-bold text-brand-navy">{c.title}</h3>
+                  <p className="mt-3 text-sm text-brand-text-2 leading-relaxed">{c.body}</p>
+                  <div className="mt-4">
+                    <Badge tone={c.tone}>{c.badge}</Badge>
+                  </div>
+                </div>
+              </StaggerItem>
+            ))}
+          </StaggerChildren>
+        </div>
+      </section>
+
+      {/* IN PRACTICE */}
+      <section className="bg-white py-20 sm:py-24">
+        <div className="container-rc">
+          <div className="grid gap-12 lg:grid-cols-2 lg:gap-16 items-center">
+            <FadeUp>
+              <Eyebrow>In Practice</Eyebrow>
+              <h2 className="mt-4 font-display text-3xl sm:text-4xl font-bold text-brand-navy leading-[1.15] text-balance">
+                See what converts — not just what&apos;s busy.
+              </h2>
+              <div className="mt-6 flex flex-col gap-4 text-brand-text-2 leading-relaxed">
+                <p>
+                  Every enquiry lands in your <Link href="/features/unified-inbox" className="text-brand-blue underline underline-offset-2">unified inbox</Link> and your <Link href="/features/pipelines" className="text-brand-blue underline underline-offset-2">pipeline</Link> with its source attached. So the breakdown of where your hires come from is always there — current, and built from real enquiries, not a memory of a busy month.
+                </p>
+              </div>
+              <CheckList className="mt-6" items={inclusions} />
+            </FadeUp>
+
+            <FadeUp delay={0.1}>
+              <SourceBreakdownMock />
+            </FadeUp>
+          </div>
+        </div>
+      </section>
+
+      <CtaBanner
+        heading="Stop guessing. Start seeing."
+        subtext="When you know which channels bring your best hires, you can grow the ones that work and stop feeding the ones that don't."
+        primary={{ label: "Register your interest", href: "/register-interest" }}
+        secondary={{ label: "See all features", href: "/features" }}
+      />
+
+      <Script
+        id="enquiry-sources-software-schema"
+        type="application/ld+json"
+        strategy="afterInteractive"
+        dangerouslySetInnerHTML={{
+          __html: buildSoftwareApplicationSchema({
+            name: "RouleurCo Enquiry Source Tracking",
+            description:
+              "Enquiry source tracking for vehicle rental companies. Every enquiry is tagged with its source — Google, Facebook, website, phone — so operators can see which channels bring hires and focus their effort where it pays.",
+            url: `${SITE_URL}/features/enquiry-sources`,
+          }),
+        }}
+      />
+    </>
+  );
+}
+
+function SourceBreakdownMock() {
+  const rows = [
+    { label: "Google", enquiries: 41, hires: 38, color: "bg-brand-blue" },
+    { label: "Word of mouth", enquiries: 19, hires: 27, color: "bg-brand-green" },
+    { label: "Facebook", enquiries: 22, hires: 14, color: "bg-indigo-500" },
+    { label: "Website", enquiries: 12, hires: 16, color: "bg-violet-500" },
+    { label: "Phone", enquiries: 6, hires: 5, color: "bg-brand-amber" },
+  ];
+  return (
+    <div className="w-full max-w-[440px] mx-auto rounded-card border border-white/10 bg-brand-navy p-6 shadow-2xl" aria-hidden="true">
+      <div className="flex items-center justify-between pb-4 mb-4 border-b border-white/10">
+        <div className="font-display text-sm font-bold text-white/85">
+          Where this month&apos;s hires came from
+        </div>
+        <span className="rounded-full bg-white/[0.06] px-2.5 py-0.5 font-display text-[10px] font-semibold text-white/45">
+          Last 30 days
+        </span>
+      </div>
+      <div className="flex items-center justify-between mb-3 text-[10px] font-display font-semibold uppercase tracking-wide text-white/35">
+        <span>Channel</span>
+        <span>Share of hires</span>
+      </div>
+      <ul className="flex flex-col gap-3.5">
+        {rows.map((r) => (
+          <li key={r.label}>
+            <div className="flex items-center justify-between mb-1.5">
+              <span className="font-display text-sm font-semibold text-white/85">{r.label}</span>
+              <span className="font-display text-xs font-bold text-white/60">{r.hires}%</span>
+            </div>
+            <div className="h-2 w-full rounded-full bg-white/[0.06]">
+              <div className={`h-2 rounded-full ${r.color}`} style={{ width: `${r.hires}%` }} />
+            </div>
+          </li>
+        ))}
+      </ul>
+      <div className="mt-5 rounded-md border border-brand-green/30 bg-brand-green/10 px-3 py-2.5 text-xs leading-relaxed text-brand-green">
+        Word of mouth brings fewer enquiries than Facebook — but more <strong>hires</strong>. That&apos;s where to lean in.
+      </div>
+    </div>
+  );
+}

--- a/app/features/hire-check-in/page.tsx
+++ b/app/features/hire-check-in/page.tsx
@@ -101,7 +101,7 @@ export default function HireCheckInPage() {
         ]}
         eyebrow="Long-Term Hire"
         heading="Once a vehicle is out on hire, the work isn't over. RouleurCo keeps the conversation going — automatically."
-        lead="Automated check-ins at 4 weeks, 6 weeks, 3 months, and through to return — collecting mileage, flagging damage early, and giving your hire desk visibility over every vehicle on long-term hire without lifting a finger."
+        lead="Long-term hires are what steady your year — so protecting and renewing them is how you grow. Automated check-ins at 4 weeks, 6 weeks, 3 months, and through to return collect mileage, flag damage early, and surface renewal intent in time — keeping every long-term vehicle utilised and your hire desk on top of it without lifting a finger."
       />
 
       {/* PROBLEM */}
@@ -113,7 +113,7 @@ export default function HireCheckInPage() {
               Vehicles on long-term hire go quiet. That silence is a risk.
             </h2>
             <p className="mt-4 text-lg text-brand-text-2 leading-relaxed max-w-3xl">
-              Once a vehicle leaves the yard on a monthly or contract hire, most rental businesses lose visibility completely until it comes back. Mileage builds up unchecked. Damage goes unreported. Renewal conversations happen too late — or not at all. And the hire desk only finds out about problems at return, when it is too late to act on them.
+              Once a vehicle leaves the yard on a monthly or long-term hire, most rental businesses lose visibility completely until it comes back. Mileage builds up unchecked. Damage goes unreported. Renewal conversations happen too late — or not at all. And the hire desk only finds out about problems at return, when it is too late to act on them.
             </p>
           </FadeUp>
 
@@ -323,8 +323,8 @@ export default function HireCheckInPage() {
       <CtaBanner
         heading="Stop finding out about problems when the vehicle comes back."
         subtext="RouleurCo active hire check-ins run automatically on every long-term hire — no manual reminders, no forgotten calls."
-        primary={{ label: "Get Early Access", href: "/contact#founding" }}
-        secondary={{ label: "See All Features", href: "/features" }}
+        primary={{ label: "Register your interest", href: "/register-interest" }}
+        secondary={{ label: "See all features", href: "/features" }}
       />
 
       <Script

--- a/app/features/lead-qualification/page.tsx
+++ b/app/features/lead-qualification/page.tsx
@@ -89,7 +89,7 @@ export default function LeadQualificationPage() {
         ]}
         eyebrow="Feature Deep Dive"
         heading="Know which enquiries are worth chasing — and stop wasting time on the ones that aren't."
-        lead="RouleurCo's enquiry qualification workflow assesses every lead the moment it arrives based on what was submitted — vehicle, dates, business name, hire type — routes it to the right nurture track automatically, and flags low-quality enquiries before your hire desk spends an hour on someone who was never going to book."
+        lead="Putting your hire desk's time on the right enquiries is how an independent operator wins more of the hires that grow the business — especially the long-term hires that steady the year. RouleurCo's enquiry qualification workflow assesses every lead the moment it arrives based on what was submitted — vehicle, dates, business name, hire type — routes it to the right nurture track automatically, and flags low-quality enquiries before your hire desk spends an hour on someone who was never going to book."
       />
 
       {/* THE PROBLEM */}
@@ -314,8 +314,8 @@ export default function LeadQualificationPage() {
       <CtaBanner
         heading="Spend your time on the enquiries worth chasing."
         subtext="Every enquiry scored, sorted and routed the moment it arrives. Your hire desk sees the best leads first — and time-wasters never make it past the qualification sequence."
-        primary={{ label: "Register as a Founding Operator", href: "/contact#founding" }}
-        secondary={{ label: "View Pricing", href: "/pricing" }}
+        primary={{ label: "Register your interest", href: "/register-interest" }}
+        secondary={{ label: "See all features", href: "/features" }}
       />
 
       <Script

--- a/app/features/missed-call/page.tsx
+++ b/app/features/missed-call/page.tsx
@@ -51,7 +51,7 @@ export default function MissedCallPage() {
         ]}
         eyebrow="Feature Deep Dive"
         heading="Every missed call gets a response. Automatically. Within seconds."
-        lead="A customer calls your hire desk. Nobody answers. Before they've put the phone down, they've already received a text from you. Works both ways — when a lead doesn't pick up your call, an automatic SMS follows immediately."
+        lead="A missed call is a hire that could grow your year — won by whoever answers first. A customer calls your hire desk, nobody answers, and before they've put the phone down they've already received a text from you. Works both ways — when a lead doesn't pick up your call, an automatic SMS follows immediately — so you capture more of the right hires, including the long-term ones."
       />
 
       {/* PROBLEM with before/after */}
@@ -220,8 +220,8 @@ export default function MissedCallPage() {
       <CtaBanner
         heading="Stop handing hires to competitors."
         subtext="Every missed call — inbound or outbound — gets an automatic SMS response within seconds. Keep the conversation alive before they call the next company on the list."
-        primary={{ label: "Register as a Founding Operator", href: "/contact#founding" }}
-        secondary={{ label: "View Pricing", href: "/pricing" }}
+        primary={{ label: "Register your interest", href: "/register-interest" }}
+        secondary={{ label: "See all features", href: "/features" }}
       />
 
       <Script

--- a/app/features/onboarding/page.tsx
+++ b/app/features/onboarding/page.tsx
@@ -122,7 +122,7 @@ export default function OnboardingPage() {
         ]}
         eyebrow="Feature Deep Dive"
         heading="No vehicle leaves without the right documents in place. RouleurCo collects them — automatically."
-        lead="Driving licence checks. Proof of insurance. Company details. Signed hire agreements. RouleurCo sends the onboarding sequence the moment a hire is confirmed, tracks what's been received, and blocks vehicle release until every required document is in place."
+        lead="Fast, watertight onboarding is how an independent operator wins more of the right hires — especially the long-term hires that steady the year — without slowing the desk down or taking on risk. Driving licence checks. Proof of insurance. Company details. Signed hire agreements. RouleurCo sends the onboarding sequence the moment a hire is confirmed, tracks what's been received, and blocks vehicle release until every required document is in place."
       />
 
       {/* PROBLEM */}
@@ -421,8 +421,8 @@ export default function OnboardingPage() {
       <CtaBanner
         heading="Documents in order before every hire."
         subtext="Automated collection, structured follow-up, and an authorisation gate that prevents release until everything is on file. No shortcuts. No gaps."
-        primary={{ label: "Register as a Founding Operator", href: "/contact#founding" }}
-        secondary={{ label: "View Pricing", href: "/pricing" }}
+        primary={{ label: "Register your interest", href: "/register-interest" }}
+        secondary={{ label: "See all features", href: "/features" }}
       />
 
       <Script

--- a/app/features/page.tsx
+++ b/app/features/page.tsx
@@ -245,7 +245,7 @@ export default function FeaturesPage() {
         crumbs={[{ label: "Home", href: "/" }, { label: "Features" }]}
         eyebrow="Platform Features"
         heading="Enterprise-level tools. Configured for rental."
-        lead="Every feature in RouleurCo is built around the vehicle rental sales process — not adapted from a generic CRM. Here's what's included."
+        lead="Everything an independent operator needs to win more of the right hires — especially the long-term hires that steady the year — and grow. Every feature is built around the vehicle rental sales process, not adapted from a generic CRM. Here's what's included."
       />
 
       <section className="bg-brand-navy text-white py-14">
@@ -344,8 +344,8 @@ export default function FeaturesPage() {
         eyebrow="Get started"
         heading="Every feature. Pre-built for rental."
         subtext="RouleurCo is ready from day one. No configuration, no adapting a generic CRM, no wasted weeks of setup."
-        primary={{ label: "Register as a Founding Operator", href: "/contact#founding" }}
-        secondary={{ label: "View Pricing", href: "/pricing" }}
+        primary={{ label: "Register your interest", href: "/register-interest" }}
+        secondary={{ label: "See how it works", href: "/how-it-works" }}
       />
 
       <Script

--- a/app/features/payments/page.tsx
+++ b/app/features/payments/page.tsx
@@ -85,7 +85,7 @@ export default function PaymentsPage() {
         ]}
         eyebrow="Feature Deep Dive"
         heading="Collect payments. Chase failures automatically. Remove payment admin entirely."
-        lead="Most hire desks spend hours every week chasing deposits, following up bounced payments, and manually confirming receipts. RouleurCo removes all of it."
+        lead="Reliable payment collection is how an independent operator turns more of the right hires — especially the long-term hires that steady the year — into cleared revenue and a growing business. Most hire desks spend hours every week chasing deposits, following up bounced payments, and manually confirming receipts. RouleurCo removes all of it."
       />
 
       {/* PROBLEM */}
@@ -226,7 +226,7 @@ export default function PaymentsPage() {
             <FadeUp>
               <Eyebrow>Direct Debit Collection</Eyebrow>
               <h2 className="mt-4 font-display text-3xl sm:text-4xl font-bold text-brand-navy leading-[1.15] text-balance">
-                GoCardless integration for recurring and contract hires.
+                GoCardless integration for recurring and long-term hires.
               </h2>
               <div className="mt-6 flex flex-col gap-4 text-brand-text-2 leading-relaxed">
                 <p>Stripe is the right tool for one-off deposits and immediate card payments. But for rental businesses running contract accounts, recurring monthly hires, or longer-term fleet arrangements — GoCardless Direct Debit is a better fit.</p>
@@ -237,7 +237,7 @@ export default function PaymentsPage() {
                 items={[
                   "Direct Debit mandates set up and managed inside RouleurCo",
                   "Automatic collection on defined payment dates",
-                  "Ideal for contract hire, fleet accounts and recurring arrangements",
+                  "Ideal for long-term hire, fleet accounts and recurring arrangements",
                   "Failed collections trigger the same automated recovery sequence as card payments",
                   "Customer notified automatically before each collection",
                 ]}
@@ -283,8 +283,8 @@ export default function PaymentsPage() {
       <CtaBanner
         heading="Stop chasing payments manually."
         subtext="Every deposit, retry, receipt and recovery sequence runs automatically. Your hire desk focuses on bookings — not bank transfers."
-        primary={{ label: "Register as a Founding Operator", href: "/contact#founding" }}
-        secondary={{ label: "View Pricing", href: "/pricing" }}
+        primary={{ label: "Register your interest", href: "/register-interest" }}
+        secondary={{ label: "See all features", href: "/features" }}
       />
 
       <Script

--- a/app/features/pipelines/page.tsx
+++ b/app/features/pipelines/page.tsx
@@ -147,7 +147,7 @@ export default function PipelinesPage() {
         ]}
         eyebrow="Feature Deep Dive"
         heading="Not every enquiry converts this week. Most operators treat them all the same. RouleurCo doesn't."
-        lead="Separate pipelines for hot leads, slow-burn enquiries, and long-term prospects — each with its own nurture sequence, its own pace, and its own triggers. Nobody slips through. Nobody gets pestered."
+        lead="Growing the business means winning more of the right hires — especially the long-term ones that steady your year. Separate pipelines for hot leads, slow-burn enquiries, and long-term prospects give each its own nurture sequence, its own pace, and its own triggers. Nobody slips through. Nobody gets pestered."
       />
 
       {/* THE PROBLEM */}
@@ -374,8 +374,8 @@ export default function PipelinesPage() {
 
       <CtaBanner
         heading="Stop losing the slow ones."
-        subtext="Multi-pipeline nurturing recovers the enquiries your current process abandons. Founding operators get the full setup included."
-        primary={{ label: "Register as a Founding Operator", href: "/contact#founding" }}
+        subtext="Multi-pipeline nurturing recovers the enquiries your current process abandons — the slow-burn and long-term ones that grow your year."
+        primary={{ label: "Register your interest", href: "/register-interest" }}
         secondary={{ label: "View All Features →", href: "/features" }}
       />
 

--- a/app/features/quote-follow-up/page.tsx
+++ b/app/features/quote-follow-up/page.tsx
@@ -1,0 +1,238 @@
+import type { Metadata } from "next";
+import Script from "next/script";
+import Link from "next/link";
+import { buildMetadata, SITE_URL } from "@/lib/metadata";
+import { buildSoftwareApplicationSchema } from "@/lib/faqSchema";
+import { PageHero } from "@/components/sections/PageHero";
+import { CtaBanner } from "@/components/sections/CtaBanner";
+import { SectionHeader } from "@/components/ui/SectionHeader";
+import { CheckList } from "@/components/ui/CheckList";
+import { Eyebrow } from "@/components/ui/Eyebrow";
+import { Badge } from "@/components/ui/Badge";
+import { FadeUp } from "@/components/motion/FadeUp";
+import { StaggerChildren, StaggerItem } from "@/components/motion/StaggerChildren";
+
+export const metadata: Metadata = buildMetadata({
+  title: "Quote Follow-Up — Every Quote Chased Until Someone Replies",
+  description:
+    "RouleurCo follows up every quote automatically, across email and SMS, until the customer replies or you close the enquiry — so hires don't go cold while the hire desk gets busy.",
+  path: "/features/quote-follow-up",
+});
+
+const capabilities = [
+  {
+    title: "The follow-up runs itself",
+    body: "Once a quote goes out, RouleurCo chases on the schedule you set — email, SMS — without anyone having to remember.",
+    badge: "Automatic",
+    tone: "blue" as const,
+  },
+  {
+    title: "Until you get an answer",
+    body: "A single templated email isn't a follow-up. RouleurCo keeps going until the customer replies or you close the enquiry.",
+    badge: "Persistent",
+    tone: "blue" as const,
+  },
+  {
+    title: "The long ones especially",
+    body: "Long-term hires often take more than one touch to land — and they're the ones that steady your year. They're worth chasing properly.",
+    badge: "Long-term hire",
+    tone: "blue" as const,
+  },
+  {
+    title: "You stay in control",
+    body: "Every follow-up is visible, every reply lands in one inbox, and you can step in the moment a customer responds.",
+    badge: "Always visible",
+    tone: "amber" as const,
+  },
+];
+
+const whyCold = [
+  "The quote goes out and the desk moves on to the next call",
+  "The customer means to reply, then forgets",
+  "Nobody owns the chase, so nobody does it",
+  "By the time someone remembers, they've booked elsewhere",
+];
+
+const inclusions = [
+  "Sequences trigger automatically when a quote is sent",
+  "Email and SMS touches on the schedule you set",
+  "Chasing stops the instant the customer replies",
+  "Long-term enquiries chased with the persistence they deserve",
+  "Every touch and reply visible in one place",
+];
+
+export default function QuoteFollowUpPage() {
+  return (
+    <>
+      <PageHero
+        crumbs={[
+          { label: "Home", href: "/" },
+          { label: "Features", href: "/features" },
+          { label: "Quote Follow-Up" },
+        ]}
+        eyebrow="Feature Deep Dive"
+        heading="Every quote, followed up — until someone replies"
+        lead="The hire you lose is rarely the one you quoted wrong. It's the one nobody chased. RouleurCo follows up automatically, across channels, so quotes don't go cold while the desk gets busy."
+      />
+
+      {/* THE PROBLEM */}
+      <section className="bg-white py-20 sm:py-24">
+        <div className="container-rc">
+          <div className="grid gap-12 lg:grid-cols-2 lg:gap-16 items-center">
+            <FadeUp>
+              <Eyebrow>The Problem</Eyebrow>
+              <h2 className="mt-4 font-display text-3xl sm:text-4xl font-bold text-brand-navy leading-[1.15] text-balance">
+                The hire you lose is the one nobody chased.
+              </h2>
+              <div className="mt-6 flex flex-col gap-4 text-brand-text-2 leading-relaxed">
+                <p>
+                  A quote goes out. The customer doesn&apos;t reply straight away — they&apos;re busy too. The hire desk gets pulled onto the next call, and the quote sits there. Nobody decided to drop it. It just quietly went cold.
+                </p>
+                <p>
+                  Chasing properly means more than one message, on more than one day, across more than one channel — and remembering to do it every single time. On a busy desk, that&apos;s exactly what doesn&apos;t happen.
+                </p>
+              </div>
+            </FadeUp>
+
+            <FadeUp delay={0.1}>
+              <div className="rounded-card border border-brand-mid bg-brand-lightbg p-8">
+                <div className="font-display text-xs font-bold uppercase tracking-[0.08em] text-brand-muted">
+                  How a quote goes cold
+                </div>
+                <ul className="mt-5 flex flex-col gap-3">
+                  {whyCold.map((q) => (
+                    <li key={q} className="flex gap-3 items-start text-sm text-brand-text-2">
+                      <span className="mt-0.5 inline-flex size-5 shrink-0 items-center justify-center rounded-full bg-brand-red/15 text-brand-red text-xs font-bold">
+                        ✕
+                      </span>
+                      <span>{q}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </FadeUp>
+          </div>
+        </div>
+      </section>
+
+      {/* CAPABILITIES */}
+      <section className="bg-brand-lightbg py-20 sm:py-24">
+        <div className="container-rc">
+          <SectionHeader
+            eyebrow="What It Does"
+            heading="Set the chase once. It runs every time."
+            lead="A structured, multi-touch follow-up on every quote — so the persistence that wins hires doesn't depend on anyone remembering."
+          />
+          <StaggerChildren className="mt-12 grid gap-5 md:grid-cols-2">
+            {capabilities.map((c) => (
+              <StaggerItem key={c.title}>
+                <div className="h-full rounded-card border border-brand-mid bg-white p-7">
+                  <h3 className="font-display text-lg font-bold text-brand-navy">{c.title}</h3>
+                  <p className="mt-3 text-sm text-brand-text-2 leading-relaxed">{c.body}</p>
+                  <div className="mt-4">
+                    <Badge tone={c.tone}>{c.badge}</Badge>
+                  </div>
+                </div>
+              </StaggerItem>
+            ))}
+          </StaggerChildren>
+
+          <FadeUp delay={0.15}>
+            <p className="mt-10 text-center text-sm text-brand-muted max-w-2xl mx-auto">
+              Different from{" "}
+              <Link href="/features/missed-call" className="text-brand-blue underline underline-offset-2">
+                Missed Call Text-Back
+              </Link>
+              , which answers a missed call in seconds. This chases a quote you&apos;ve already sent — over days, until you get an answer.
+            </p>
+          </FadeUp>
+        </div>
+      </section>
+
+      {/* IN PRACTICE */}
+      <section className="bg-white py-20 sm:py-24">
+        <div className="container-rc">
+          <div className="grid gap-12 lg:grid-cols-2 lg:gap-16 items-center">
+            <FadeUp>
+              <Eyebrow>In Practice</Eyebrow>
+              <h2 className="mt-4 font-display text-3xl sm:text-4xl font-bold text-brand-navy leading-[1.15] text-balance">
+                A follow-up that doesn&apos;t rely on memory.
+              </h2>
+              <div className="mt-6 flex flex-col gap-4 text-brand-text-2 leading-relaxed">
+                <p>
+                  The sequence fires the moment a quote is marked sent and runs in the background. Every reply lands in your{" "}
+                  <Link href="/features/unified-inbox" className="text-brand-blue underline underline-offset-2">unified inbox</Link>, and the enquiry moves through your{" "}
+                  <Link href="/features/pipelines" className="text-brand-blue underline underline-offset-2">pipeline</Link> as it goes — so you always know what&apos;s been chased and what&apos;s landed.
+                </p>
+              </div>
+              <CheckList className="mt-6" items={inclusions} />
+            </FadeUp>
+
+            <FadeUp delay={0.1}>
+              <FollowUpSequenceMock />
+            </FadeUp>
+          </div>
+        </div>
+      </section>
+
+      <CtaBanner
+        heading="Stop losing the quotes nobody chased."
+        subtext="Set the follow-up once and every quote gets chased — especially the long-term ones that steady your year — until you get an answer."
+        primary={{ label: "Register your interest", href: "/register-interest" }}
+        secondary={{ label: "See all features", href: "/features" }}
+      />
+
+      <Script
+        id="quote-follow-up-software-schema"
+        type="application/ld+json"
+        strategy="afterInteractive"
+        dangerouslySetInnerHTML={{
+          __html: buildSoftwareApplicationSchema({
+            name: "RouleurCo Quote Follow-Up",
+            description:
+              "Automated quote follow-up for vehicle rental companies. Every quote is chased automatically across email and SMS until the customer replies or the enquiry is closed.",
+            url: `${SITE_URL}/features/quote-follow-up`,
+          }),
+        }}
+      />
+    </>
+  );
+}
+
+function FollowUpSequenceMock() {
+  const nodes = [
+    { kind: "trigger" as const, label: "Quote sent", sub: "Sequence starts automatically" },
+    { kind: "delay" as const, label: "Day 2 — no reply", sub: "Customer hasn't responded" },
+    { kind: "action" as const, label: "SMS nudge sent", sub: "Personalised to their enquiry" },
+    { kind: "delay" as const, label: "Day 4 — still nothing", sub: "Quote would normally go cold here" },
+    { kind: "action" as const, label: "Email follow-up sent", sub: "Quote attached again" },
+    { kind: "reply" as const, label: "Day 7 — customer replies", sub: "Sequence stops — over to you" },
+  ];
+  const colors = {
+    trigger: { dot: "bg-brand-blue", ring: "ring-brand-blue/30", label: "text-brand-blue" },
+    delay: { dot: "bg-brand-amber", ring: "ring-brand-amber/30", label: "text-brand-amber" },
+    action: { dot: "bg-brand-green", ring: "ring-brand-green/30", label: "text-brand-green" },
+    reply: { dot: "bg-brand-blue", ring: "ring-brand-blue/40", label: "text-brand-blue" },
+  };
+  return (
+    <div className="w-full max-w-[360px] mx-auto" aria-hidden="true">
+      {nodes.map((n, i) => {
+        const c = colors[n.kind];
+        return (
+          <div key={i}>
+            <div className={`flex items-start gap-3 rounded-xl border border-brand-mid bg-white p-3.5 ring-1 ${c.ring}`}>
+              <span className={`mt-1.5 inline-block size-2.5 rounded-full ${c.dot}`} />
+              <div>
+                <div className={`font-display text-xs font-semibold uppercase tracking-wide ${c.label}`}>
+                  {n.label}
+                </div>
+                <div className="text-xs text-brand-text-2 mt-0.5">{n.sub}</div>
+              </div>
+            </div>
+            {i < nodes.length - 1 && <div className="ml-[18px] h-5 w-px bg-brand-mid" />}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/features/social-media/page.tsx
+++ b/app/features/social-media/page.tsx
@@ -68,7 +68,7 @@ export default function SocialMediaPage() {
         ]}
         eyebrow="Feature Deep Dive"
         heading="Create, schedule and publish social content — without leaving RouleurCo."
-        lead="Most rental companies know they should be posting regularly. Almost none of them do — because it's one more thing to manage in a separate tool. RouleurCo brings social scheduling into the same system as your CRM and inbox."
+        lead="Staying visible is how you win more of the right hires — the steady long-term ones that grow the business. Most rental companies know they should be posting regularly, but almost none do, because it's one more thing to manage in a separate tool. RouleurCo brings social scheduling into the same system as your CRM and inbox."
       />
 
       {/* PROBLEM */}
@@ -241,8 +241,8 @@ export default function SocialMediaPage() {
       <CtaBanner
         heading="Stay visible. Stay consistent. Win more local hires."
         subtext="Schedule weeks of social content in one sitting — connected to your inbox so every enquiry from social is captured and followed up automatically."
-        primary={{ label: "Register as a Founding Operator", href: "/contact#founding" }}
-        secondary={{ label: "View Pricing", href: "/pricing" }}
+        primary={{ label: "Register your interest", href: "/register-interest" }}
+        secondary={{ label: "See all features", href: "/features" }}
       />
 
       <Script

--- a/app/features/unified-inbox/page.tsx
+++ b/app/features/unified-inbox/page.tsx
@@ -55,7 +55,7 @@ export default function UnifiedInboxPage() {
         ]}
         eyebrow="Feature Deep Dive"
         heading="Every message. Every channel. One inbox — and your team talking inside it too."
-        lead="SMS, email, Facebook Messenger, Instagram DMs, web chat — and internal team notes — all in one place. No more missed messages because someone forgot to check a platform."
+        lead="Win more of the right hires by answering first: SMS, email, Facebook Messenger, Instagram DMs, web chat — and internal team notes — all in one place. No more missed messages, including the long-term hires that steady your year, because someone forgot to check a platform."
       />
 
       {/* THE PROBLEM */}
@@ -278,8 +278,8 @@ export default function UnifiedInboxPage() {
       <CtaBanner
         heading="Never miss another message."
         subtext="Every channel your customers use to reach you — SMS, email, Facebook, Instagram, web chat — in one inbox your whole team works from."
-        primary={{ label: "Register as a Founding Operator", href: "/contact#founding" }}
-        secondary={{ label: "View Pricing", href: "/pricing" }}
+        primary={{ label: "Register your interest", href: "/register-interest" }}
+        secondary={{ label: "See all features", href: "/features" }}
       />
 
       <Script

--- a/app/growth-check/page.tsx
+++ b/app/growth-check/page.tsx
@@ -1,0 +1,138 @@
+import type { Metadata } from "next";
+import { buildMetadata } from "@/lib/metadata";
+import { PageHero } from "@/components/sections/PageHero";
+import { CtaBanner } from "@/components/sections/CtaBanner";
+import { SectionHeader } from "@/components/ui/SectionHeader";
+import { Eyebrow } from "@/components/ui/Eyebrow";
+import { FadeUp } from "@/components/motion/FadeUp";
+import { StaggerChildren, StaggerItem } from "@/components/motion/StaggerChildren";
+
+export const metadata: Metadata = buildMetadata({
+  title: "The Hire Desk Growth Check",
+  description:
+    "A 10-minute checklist for independent vehicle rental operators. The questions worth asking about your own hire desk — and an honest read on whether you can answer them. No score, no sign-up.",
+  path: "/growth-check",
+});
+
+type Question = { title: string; body: string };
+
+const gettingFound: Question[] = [
+  {
+    title: "Google Business Profile",
+    body: "When someone searches “van hire near me,” do you show up — and does what they see make them call you over the unit down the road? Is your profile complete, are your photos current, are you replying to reviews? For a local operator, GBP often does more than the website.",
+  },
+  {
+    title: "Facebook",
+    body: "When someone messages your page about a van for next week, who sees it, and how fast? Messenger enquiries are some of the warmest you'll get — and some of the easiest to miss.",
+  },
+  {
+    title: "Do you know where your enquiries come from?",
+    body: "Phone, Google, Facebook, website, word of mouth. If you can't say which channel brings the most hires, you can't lean into the one that's working.",
+  },
+];
+
+const converting: Question[] = [
+  {
+    title: "What's your response time?",
+    body: "Not your best day — your average. The first business to reply often wins the hire, especially against a slow national network. Do you know yours?",
+  },
+  {
+    title: "What happens after a quote goes out?",
+    body: "If the customer doesn't reply, who chases, and when? Or does it quietly go cold while the desk gets busy again?",
+  },
+  {
+    title: "How many enquiries do you get a month — and how many do you lose?",
+    body: "Most operators can name their bookings. Far fewer can name the ones that got away.",
+  },
+  {
+    title: "Are you winning enough long-term hire?",
+    body: "The daily work is capped by your yard. The longer hires fill the quiet months — are you converting your share, or letting them slip to someone who followed up faster?",
+  },
+];
+
+export default function GrowthCheckPage() {
+  return (
+    <>
+      <PageHero
+        crumbs={[{ label: "Home", href: "/" }, { label: "Growth Check" }]}
+        eyebrow="A checklist worth ten minutes"
+        badge={{ tone: "blue", label: "No score · No sign-up" }}
+        heading="The Hire Desk Growth Check"
+        lead="Most rental businesses are busier than they are measured. Here are the questions worth asking about your own desk — and an honest read on whether you can actually answer them."
+      />
+
+      {/* SECTION 1 — Are you getting found? */}
+      <section className="bg-white py-20 sm:py-24">
+        <div className="container-rc">
+          <SectionHeader
+            eyebrow="Section 1"
+            heading="Are you getting found?"
+          />
+          <StaggerChildren className="mt-12 grid gap-5 md:grid-cols-3">
+            {gettingFound.map((q, i) => (
+              <QuestionCard key={q.title} n={i + 1} question={q} />
+            ))}
+          </StaggerChildren>
+        </div>
+      </section>
+
+      {/* SECTION 2 — Are you converting what you get? */}
+      <section className="bg-brand-lightbg py-20 sm:py-24">
+        <div className="container-rc">
+          <SectionHeader
+            eyebrow="Section 2"
+            heading="Are you converting what you get?"
+          />
+          <StaggerChildren className="mt-12 grid gap-5 md:grid-cols-2">
+            {converting.map((q, i) => (
+              <QuestionCard key={q.title} n={i + 1} question={q} />
+            ))}
+          </StaggerChildren>
+        </div>
+      </section>
+
+      {/* THE POINT */}
+      <section className="bg-brand-navy py-20 sm:py-24 text-white">
+        <div className="container-rc max-w-3xl text-center">
+          <FadeUp>
+            <Eyebrow variant="white">The point</Eyebrow>
+            <h2 className="mt-4 font-display text-3xl sm:text-4xl lg:text-5xl font-bold leading-[1.1] text-balance">
+              You can&apos;t grow what you can&apos;t see.
+            </h2>
+            <p className="mt-6 text-lg text-white/80 leading-relaxed">
+              If you couldn&apos;t answer some of those with confidence, you&apos;re not behind — you&apos;re normal. Almost no independent has this visible, because the systems that run the fleet and hold the emails were never built to show it.
+            </p>
+            <p className="mt-4 text-lg text-white/80 leading-relaxed">
+              That&apos;s the half of the business RouleurCo makes visible: every enquiry captured, every source tracked, every quote followed up, every number in one place. You can&apos;t improve a response time you can&apos;t see, or grow a channel you didn&apos;t know was working.
+            </p>
+          </FadeUp>
+        </div>
+      </section>
+
+      <CtaBanner
+        heading="Want to see what that looks like for your desk?"
+        subtext="Register your interest and we'll show you how RouleurCo makes the commercial side of your hire desk visible — and what it'd mean for how yours runs."
+        primary={{ label: "Register your interest", href: "/register-interest" }}
+        secondary={{ label: "See how it works", href: "/how-it-works" }}
+      />
+    </>
+  );
+}
+
+function QuestionCard({ n, question }: { n: number; question: Question }) {
+  return (
+    <StaggerItem>
+      <div className="flex h-full flex-col rounded-card border border-brand-mid bg-white p-7">
+        <span className="inline-flex size-9 items-center justify-center rounded-lg bg-brand-blue-light font-display text-sm font-bold text-brand-blue">
+          {n}
+        </span>
+        <h3 className="mt-4 font-display text-lg font-bold text-brand-navy leading-snug">
+          {question.title}
+        </h3>
+        <p className="mt-3 text-sm text-brand-text-2 leading-relaxed">
+          {question.body}
+        </p>
+      </div>
+    </StaggerItem>
+  );
+}

--- a/app/how-it-works/page.tsx
+++ b/app/how-it-works/page.tsx
@@ -91,6 +91,7 @@ export default function HowItWorksPage() {
               ]}
               before="You've a rough feel for where work comes from — but no numbers, so marketing spend is a guess."
               visual={<OpportunityVisual />}
+              link={{ label: "See enquiry source tracking", href: "/features/enquiry-sources" }}
               reverse
             />
             <Step
@@ -106,7 +107,7 @@ export default function HowItWorksPage() {
               ]}
               before="Quote sent. Desk gets busy. The customer books with whoever followed up. You never find out why."
               visual={<FollowUpVisual />}
-              link={{ label: "See follow-up automation", href: "/features/missed-call" }}
+              link={{ label: "See quote follow-up", href: "/features/quote-follow-up" }}
             />
             <Step
               num="04"

--- a/app/how-it-works/page.tsx
+++ b/app/how-it-works/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Script from "next/script";
+import Link from "next/link";
 import { buildMetadata } from "@/lib/metadata";
 import { PageHero } from "@/components/sections/PageHero";
 import { CtaBanner } from "@/components/sections/CtaBanner";
@@ -11,45 +12,30 @@ import { FadeUp } from "@/components/motion/FadeUp";
 import { StaggerChildren, StaggerItem } from "@/components/motion/StaggerChildren";
 
 export const metadata: Metadata = buildMetadata({
-  title: "How RouleurCo Works — Enquiry to Hire, Automated",
+  title: "How RouleurCo Works — The Commercial Layer for Your Hire Desk",
   description:
-    "From the first enquiry to a confirmed hire — see how RouleurCo structures the rental sales process and removes the gaps where hires get lost.",
+    "How RouleurCo helps independent rental companies grow: capture every enquiry, see where your hires come from, follow up every quote, and convert more long-term hire.",
   path: "/how-it-works",
 });
 
-const problems = [
-  {
-    title: "Notes on notepads",
-    body: "Enquiry details written on paper. Passed between staff verbally. Lost between shifts. No visibility for anyone else on the team.",
-  },
-  {
-    title: "Messages missed for hours",
-    body: "Facebook messages. Web chat. Email to a shared inbox. No single place to check — things sit unread while the hire desk is on the phone.",
-  },
-  {
-    title: "Follow-up never happens",
-    body: "Quote sent. Customer doesn't reply immediately. The hire desk gets busy. The enquiry sits there. The customer books with someone who followed up.",
-  },
-];
-
 const setupSteps = [
-  { n: 1, title: "Register Interest", body: "Register as a founding operator. We'll be in touch within 24 hours." },
-  { n: 2, title: "Onboarding Call", body: "A personal setup call to configure your pipeline, inbox and automations." },
-  { n: 3, title: "Import Contacts", body: "Bring your existing customer list in. Or start fresh with new enquiries." },
-  { n: 4, title: "Start Converting", body: "Enquiries flowing in. Follow-ups running automatically. Hires confirmed." },
+  { n: 1, title: "Register your interest", body: "Tell us where to reach you. We'll be in touch within two business days." },
+  { n: 2, title: "Onboarding call", body: "A short setup call to configure your pipeline, inbox and follow-ups around how your desk runs." },
+  { n: 3, title: "Import your contacts", body: "Bring your existing customer list in, or start fresh with new enquiries." },
+  { n: 4, title: "Start converting", body: "Enquiries captured, sources tracked, follow-ups running, more hires landing." },
 ];
 
 const howToSchema = {
   "@context": "https://schema.org",
   "@type": "HowTo",
-  name: "How RouleurCo Works — From Enquiry to Confirmed Hire",
+  name: "How RouleurCo Grows Your Hire Desk",
   description:
-    "How RouleurCo structures the rental sales process — capturing enquiries from every channel and turning them into confirmed hires automatically.",
+    "How RouleurCo runs the commercial side of an independent rental business — capturing every enquiry, tracking where hires come from, following up every quote, and converting more long-term hire.",
   step: [
-    { "@type": "HowToStep", position: 1, name: "Enquiry Captured", text: "Every channel flows into one system. Web, email, social, phone. Nothing gets missed." },
-    { "@type": "HowToStep", position: 2, name: "Opportunity Structured", text: "Customer record created automatically. Vehicle, dates, source all recorded. Acknowledgement sent to customer." },
-    { "@type": "HowToStep", position: 3, name: "Quote Sent — Follow-up Automated", text: "Quote sent from the platform. Automated follow-up sequence starts immediately. SMS and email at timed intervals." },
-    { "@type": "HowToStep", position: 4, name: "Hire Confirmed", text: "Documents collected, e-signature obtained, deposit taken. All automated. Hire confirmed and recorded." },
+    { "@type": "HowToStep", position: 1, name: "Capture every enquiry", text: "Phone, email, website, Facebook and missed calls all flow into one inbox the moment they land. Nothing slips while the desk is busy." },
+    { "@type": "HowToStep", position: 2, name: "Know where your work comes from", text: "The source of every enquiry is recorded — Google, Facebook, the phone, word of mouth — so you can lean into what's converting." },
+    { "@type": "HowToStep", position: 3, name: "Follow up until they reply", text: "Every quote is chased automatically across SMS and email until the customer answers. Chasing stops the moment they reply." },
+    { "@type": "HowToStep", position: 4, name: "Convert more long-term hire", text: "Every enquiry moves through clear pipeline stages to a confirmed, earning hire — with the long-term opportunities prioritised." },
   ],
 };
 
@@ -58,112 +44,106 @@ export default function HowItWorksPage() {
     <>
       <PageHero
         crumbs={[{ label: "Home", href: "/" }, { label: "How It Works" }]}
-        eyebrow="The Process"
-        heading="From enquiry to confirmed hire. Without the gaps."
-        lead="Here's exactly how RouleurCo structures the rental sales process — and where it fixes the gaps that cost most operators hires every week."
+        eyebrow="How it works"
+        heading="How RouleurCo wins you more of the work."
+        lead="RouleurCo runs the commercial side of your hire desk — capturing every enquiry, showing you where your hires come from, chasing every quote, and converting more of the long-term work that steadies your year. Here's how."
       />
 
-      {/* Reality check */}
-      <section className="bg-brand-lightbg py-20 sm:py-24">
-        <div className="container-rc">
-          <SectionHeader
-            eyebrow="The Reality"
-            heading="How most hire desks handle enquiries today."
-            lead="Before RouleurCo, this is what enquiry management looks like for most independent rental operators."
-          />
-          <StaggerChildren className="mt-12 grid gap-5 md:grid-cols-3">
-            {problems.map((p) => (
-              <StaggerItem key={p.title}>
-                <div className="relative h-full rounded-card border border-brand-red/30 bg-white p-7">
-                  <Badge tone="red" className="absolute right-4 top-4">PROBLEM</Badge>
-                  <h3 className="font-display text-lg font-bold text-brand-navy pr-20">{p.title}</h3>
-                  <p className="mt-3 text-sm text-brand-text-2 leading-relaxed">{p.body}</p>
-                </div>
-              </StaggerItem>
-            ))}
-          </StaggerChildren>
-          <FadeUp delay={0.15}>
-            <p className="mt-10 text-center font-display text-lg font-bold text-brand-navy">
-              This isn&apos;t a people problem. It&apos;s a process problem.
-              <br />
-              <span className="text-brand-blue">RouleurCo fixes the process.</span>
-            </p>
-          </FadeUp>
-        </div>
-      </section>
-
-      {/* 4 Steps */}
+      {/* The four mechanisms */}
       <section className="bg-white py-20 sm:py-24">
         <div className="container-rc">
           <FadeUp>
-            <Eyebrow>How RouleurCo Works</Eyebrow>
+            <Eyebrow>The four moving parts</Eyebrow>
             <h2 className="mt-4 font-display text-3xl sm:text-4xl font-bold text-brand-navy leading-[1.15] text-balance max-w-2xl">
-              The rental sales process. Structured and automated.
+              Growth isn&apos;t one big move. It&apos;s four things done well, every day.
             </h2>
             <p className="mt-4 text-lg text-brand-text-2 leading-relaxed max-w-2xl">
-              Here&apos;s how RouleurCo takes an enquiry from any channel and turns it into a confirmed hire — without relying on your team to remember to follow up.
+              Each one is part of the commercial side of the business — the half that decides whether you grow. Here&apos;s what RouleurCo does, and where each piece goes deeper.
             </p>
           </FadeUp>
 
           <div className="mt-16 flex flex-col gap-20">
             <Step
               num="01"
-              eyebrow="Step 1"
-              heading="Enquiry arrives — from any channel"
-              lead="A customer enquires about a van hire. It doesn't matter whether they came through your website, sent an email, messaged on Facebook, or called the office."
+              eyebrow="Capture"
+              heading="Every enquiry, from everywhere — in one place"
+              lead="Growth starts with not losing the enquiries you've already earned. Phone, email, website, Facebook, a missed call at 9pm — RouleurCo pulls every channel into one inbox the moment it lands, so nothing slips while the desk is busy."
               bullets={[
-                "Website forms flow directly into the pipeline",
-                "Emails automatically become enquiry records",
-                "Social messages land in the unified inbox",
-                "Phone calls can be logged manually in seconds",
+                "Website forms flow straight into the pipeline",
+                "Emails become enquiry records automatically",
+                "Facebook and web chat land in one unified inbox",
+                "Phone calls logged in seconds, with the detail kept",
               ]}
               before="You check three different inboxes, a notepad on the desk, and your personal email. Maybe. If you remember."
               visual={<ChannelsVisual />}
+              link={{ label: "See the unified inbox", href: "/features/unified-inbox" }}
             />
             <Step
               num="02"
-              eyebrow="Step 2"
-              heading="Enquiry is structured as an opportunity"
-              lead="Every enquiry becomes a structured opportunity in the pipeline. The customer details, vehicle requirements, dates and source are all captured and visible to the whole team."
+              eyebrow="Measure"
+              heading="Know where your work actually comes from"
+              lead="You can't grow a channel you can't see. RouleurCo records the source of every enquiry — Google, Facebook, the phone, word of mouth — so you can lean into what's converting and stop spending on guesswork."
               bullets={[
-                "Customer record created automatically",
-                "Vehicle type, dates and hire duration recorded",
-                "Opportunity assigned to a team member",
-                "Acknowledgement message sent to customer automatically",
+                "Source captured on every enquiry, automatically",
+                "See which channels bring the most hires",
+                "Spot the ones quietly winning you long-term work",
+                "Put your effort where it's already paying",
               ]}
-              before="The person who took the call has the info. No-one else knows about it. If they're off sick, the customer hears nothing."
+              before="You've a rough feel for where work comes from — but no numbers, so marketing spend is a guess."
               visual={<OpportunityVisual />}
               reverse
             />
             <Step
               num="03"
-              eyebrow="Step 3"
-              heading="Quote sent. Follow-up sequence starts automatically."
-              lead="Your team sends the quote. At that moment, RouleurCo starts the follow-up sequence automatically. No one needs to remember to follow up — it just happens."
+              eyebrow="Chase"
+              heading="Follow up until someone replies"
+              lead="The first business to reply often wins the hire — and most enquiries that go cold weren't lost, just never chased. RouleurCo chases every quote automatically, across SMS and email, until you get an answer."
               bullets={[
-                "Quote sent directly from within the platform",
-                "Automated SMS follow-up after 24 hours if no reply",
-                "Automated email follow-up after 48 hours",
-                "Sequence stops the moment the customer responds",
+                "Follow-up sequence starts the moment a quote goes out",
+                "Automated SMS and email at timed intervals",
+                "Chasing stops the instant the customer replies",
+                "No quote left to go cold on a busy day",
               ]}
-              before="Quote sent. Hire desk gets busy. Customer never hears back. They've already booked with someone else by the time you remember."
+              before="Quote sent. Desk gets busy. The customer books with whoever followed up. You never find out why."
               visual={<FollowUpVisual />}
+              link={{ label: "See follow-up automation", href: "/features/missed-call" }}
             />
             <Step
               num="04"
-              eyebrow="Step 4"
-              heading="Customer confirms. Documents collected. Payment taken."
-              lead="Customer says yes. RouleurCo sends the hire agreement for e-signature and the deposit request automatically. No chasing. No paperwork delays."
+              eyebrow="Convert"
+              heading="Turn more enquiries — especially the long ones — into booked vehicles"
+              lead="A structured desk converts more of what it captures. RouleurCo moves every enquiry through clear stages to a confirmed, earning hire — and makes the long-term enquiries that steady your year the ones you chase hardest."
               bullets={[
-                "Hire agreement sent with one click",
-                "Customer signs on any device — no printing required",
-                "Payment link sent automatically on confirmation",
-                "Document reminders if not completed within set time",
+                "Every enquiry tracked through clear pipeline stages",
+                "Long-term opportunities flagged and prioritised",
+                "Agreements signed and deposits taken in-platform",
+                "More of the work that lifts your quiet months",
               ]}
+              before="The daily hires get chased. The long-term enquiry that could've filled February slips quietly away."
               visual={<ConfirmVisual />}
+              link={{ label: "See enquiry pipelines", href: "/features/pipelines" }}
               reverse
             />
           </div>
+        </div>
+      </section>
+
+      {/* Commercial layer positioning */}
+      <section className="bg-brand-lightbg py-20 sm:py-24">
+        <div className="container-rc max-w-3xl text-center">
+          <FadeUp>
+            <Eyebrow>The commercial layer</Eyebrow>
+            <h2 className="mt-4 font-display text-3xl sm:text-4xl font-bold text-brand-navy leading-[1.15] text-balance">
+              RouleurCo isn&apos;t a fleet system, and it isn&apos;t trying to replace one.
+            </h2>
+            <p className="mt-5 text-lg text-brand-text-2 leading-relaxed">
+              Your fleet software runs the vehicles. Your inbox holds the emails. Neither one is making sure the long-term enquiry gets chased, or telling you which channel your hires come from. That&apos;s the commercial side — and it&apos;s the half of the business that decides whether you grow.
+            </p>
+            <p className="mt-6 font-display text-xl sm:text-2xl font-bold text-brand-navy text-balance">
+              Keep what runs your fleet.{" "}
+              <span className="text-brand-blue">RouleurCo runs the part that wins the work.</span>
+            </p>
+          </FadeUp>
         </div>
       </section>
 
@@ -171,7 +151,7 @@ export default function HowItWorksPage() {
       <section className="bg-brand-navy py-20 sm:py-24 text-white">
         <div className="container-rc">
           <SectionHeader
-            eyebrow="Getting Set Up"
+            eyebrow="Getting set up"
             heading="Up and running in days."
             lead="RouleurCo comes pre-configured with rental workflows. We handle the setup — you don't need a technical team or weeks of configuration."
             variant="dark"
@@ -193,10 +173,10 @@ export default function HowItWorksPage() {
       </section>
 
       <CtaBanner
-        heading="Ready to see it in action?"
-        subtext="Register as a founding operator and get the full setup — configured for your rental business."
-        primary={{ label: "Register as a Founding Operator", href: "/contact#founding" }}
-        secondary={{ label: "View Pricing", href: "/pricing" }}
+        heading="Want to see what it'd do for your desk?"
+        subtext="Register your interest and we'll show you how RouleurCo would map to how your hire desk runs. No commitment."
+        primary={{ label: "Register your interest", href: "/register-interest" }}
+        secondary={{ label: "Take the Growth Check", href: "/growth-check" }}
       />
 
       <Script
@@ -218,6 +198,7 @@ function Step({
   before,
   visual,
   reverse,
+  link,
 }: {
   num: string;
   eyebrow: string;
@@ -227,6 +208,7 @@ function Step({
   before?: string;
   visual: React.ReactNode;
   reverse?: boolean;
+  link?: { label: string; href: string };
 }) {
   return (
     <div className={`grid gap-10 lg:grid-cols-2 lg:gap-16 items-center ${reverse ? "lg:[&>div:first-child]:order-2" : ""}`}>
@@ -244,10 +226,19 @@ function Step({
           {before && (
             <div className="mt-6 rounded-card bg-brand-lightbg border-l-4 border-brand-blue p-5">
               <p className="text-sm text-brand-text-2 leading-relaxed">
-                <strong className="font-display text-brand-navy">Before RouleurCo:</strong>{" "}
+                <strong className="font-display text-brand-navy">Without it:</strong>{" "}
                 {before}
               </p>
             </div>
+          )}
+          {link && (
+            <Link
+              href={link.href}
+              className="mt-6 inline-flex items-center gap-1.5 text-sm font-display font-semibold text-brand-blue hover:text-brand-navy"
+            >
+              {link.label}
+              <span aria-hidden="true">→</span>
+            </Link>
           )}
         </div>
       </FadeUp>
@@ -278,7 +269,7 @@ function ChannelsVisual() {
         ))}
       </div>
       <div className="mt-3 rounded-card bg-brand-blue p-4 text-center text-white">
-        <div className="font-display text-sm font-bold">→ RouleurCo Pipeline</div>
+        <div className="font-display text-sm font-bold">→ RouleurCo Inbox</div>
         <div className="text-xs text-white/70 mt-1">All enquiries. One place.</div>
       </div>
     </div>
@@ -299,8 +290,8 @@ function OpportunityVisual() {
       <div className="grid grid-cols-2 gap-3 text-xs">
         {[
           ["VEHICLE", "Transit x3"],
-          ["DURATION", "2 weeks"],
-          ["SOURCE", "Web form"],
+          ["DURATION", "6 months"],
+          ["SOURCE", "Google"],
           ["ASSIGNED", "Dave H."],
         ].map(([k, v]) => (
           <div key={k}>
@@ -310,7 +301,7 @@ function OpportunityVisual() {
         ))}
       </div>
       <div className="mt-4 rounded-md border border-brand-green/30 bg-brand-green/10 px-3 py-2 text-xs font-display font-semibold text-brand-green">
-        ✓ Acknowledgement sent automatically
+        ✓ Source tracked: Google
       </div>
     </div>
   );
@@ -359,23 +350,23 @@ function ConfirmVisual() {
       <div className="rounded-card border border-brand-mid bg-white p-5 mb-2.5">
         <div className="flex items-center justify-between mb-2">
           <span className="font-display text-[10px] font-bold uppercase tracking-wide text-brand-muted">
-            Hire Agreement
+            Long-Term Hire
           </span>
-          <Badge tone="green">SIGNED</Badge>
+          <Badge tone="green">BOOKED</Badge>
         </div>
         <div className="font-display text-sm font-bold text-brand-navy">Hartley Building Services</div>
-        <div className="text-xs text-brand-muted mt-1">Transit x3 · 2 weeks · £1,680</div>
+        <div className="text-xs text-brand-muted mt-1">Transit x3 · 6 months · earning year-round</div>
       </div>
       <div className="flex items-center justify-between rounded-card border border-brand-green/30 bg-brand-green/10 p-4 mb-2.5">
         <div>
           <div className="font-display text-xs font-bold text-brand-navy">Deposit received</div>
           <div className="text-xs text-brand-muted">Via payment link</div>
         </div>
-        <div className="font-display text-base font-bold text-brand-green">£336</div>
+        <div className="font-display text-base font-bold text-brand-green">Paid</div>
       </div>
       <div className="rounded-card bg-brand-blue p-4 text-center text-white">
         <div className="font-display text-sm font-bold">✓ Hire Confirmed</div>
-        <div className="text-xs text-white/70 mt-1">Moved to Confirmed in pipeline</div>
+        <div className="text-xs text-white/70 mt-1">A vehicle earning through the quiet months</div>
       </div>
     </div>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,19 +3,18 @@ import Script from "next/script";
 import { buildMetadata, SITE_URL } from "@/lib/metadata";
 import { buildSoftwareApplicationSchema } from "@/lib/faqSchema";
 import { HomeHero } from "@/components/sections/home/HomeHero";
-import { LogosBar } from "@/components/sections/home/LogosBar";
-import { ProblemSection } from "@/components/sections/home/ProblemSection";
-import { FeaturesTabsSection } from "@/components/sections/home/FeaturesTabsSection";
-import { StatsStrip } from "@/components/sections/home/StatsStrip";
-import { HowItWorksSummary } from "@/components/sections/home/HowItWorksSummary";
-import { FoundingSection } from "@/components/sections/home/FoundingSection";
-import { WhyWeBuiltSection } from "@/components/sections/home/WhyWeBuiltSection";
-import { FinalCTA } from "@/components/sections/home/FinalCTA";
+import { CeilingSection } from "@/components/sections/home/CeilingSection";
+import { LeverSection } from "@/components/sections/home/LeverSection";
+import { CompetitionSection } from "@/components/sections/home/CompetitionSection";
+import { MechanismsSection } from "@/components/sections/home/MechanismsSection";
+import { CommercialLayerSection } from "@/components/sections/home/CommercialLayerSection";
+import { ResultSection } from "@/components/sections/home/ResultSection";
+import { RegisterInterestCTA } from "@/components/sections/home/RegisterInterestCTA";
 
 export const metadata: Metadata = buildMetadata({
-  title: "RouleurCo | Sales & Automation for Vehicle Rental Companies",
+  title: "RouleurCo | Grow Your Vehicle Rental Business",
   description:
-    "Enterprise-level sales and automation software built for independent vehicle rental companies. Capture every enquiry, automate follow-ups, and convert more hires.",
+    "RouleurCo helps independent vehicle rental companies grow — winning more of the right hires, especially long-term ones, so the fleet earns year-round. The commercial layer that sits alongside your fleet software.",
   path: "/",
 });
 
@@ -23,14 +22,13 @@ export default function HomePage() {
   return (
     <>
       <HomeHero />
-      <LogosBar />
-      <ProblemSection />
-      <FeaturesTabsSection />
-      <StatsStrip />
-      <HowItWorksSummary />
-      <FoundingSection />
-      <WhyWeBuiltSection />
-      <FinalCTA />
+      <CeilingSection />
+      <LeverSection />
+      <CompetitionSection />
+      <MechanismsSection />
+      <CommercialLayerSection />
+      <ResultSection />
+      <RegisterInterestCTA />
       <Script
         id="home-software-schema"
         type="application/ld+json"
@@ -38,7 +36,7 @@ export default function HomePage() {
         dangerouslySetInnerHTML={{
           __html: buildSoftwareApplicationSchema({
             description:
-              "Sales and automation platform configured for vehicle rental companies — pipelines, unified inbox, automated follow-ups, e-signature and payments.",
+              "The commercial layer for independent vehicle rental companies — capture every enquiry, track where hires come from, follow up every quote, and convert more long-term hire. Sits alongside your fleet software.",
             url: SITE_URL,
           }),
         }}

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -58,7 +58,7 @@ export default function PrivacyPage() {
             <p>We use the personal information you provide to:</p>
             <ul>
               <li>Respond to your enquiry and provide information about RouleurCo</li>
-              <li>Contact you about securing a founding operator position, where you have expressed interest</li>
+              <li>Contact you about your interest in RouleurCo and arrange a conversation, where you have expressed interest</li>
               <li>Send follow-up communications related to your enquiry, where you have provided consent via the contact form</li>
               <li>Improve our website and communications based on how visitors interact with our content</li>
             </ul>
@@ -75,7 +75,7 @@ export default function PrivacyPage() {
             <h2>4. Who we share your data with</h2>
             <p>We do not sell your personal data. We may share it with the following third parties, only where necessary to provide our service:</p>
             <ul>
-              <li><strong>GoHighLevel</strong> — our CRM and communications platform, which processes enquiry data on our behalf. GoHighLevel acts as a data processor under our instruction.</li>
+              <li><strong>Our CRM and communications platform</strong> — a third-party provider that processes enquiry data on our behalf and acts as a data processor under our instruction.</li>
               <li><strong>Google Analytics</strong> — we use Google Analytics to understand how visitors interact with our website. Data collected is anonymised and subject to Google&apos;s privacy policy.</li>
             </ul>
             <p>All third parties we work with are required to handle your data in accordance with applicable data protection law.</p>
@@ -112,10 +112,10 @@ export default function PrivacyPage() {
             <p>You also have the right to lodge a complaint with the <strong>Information Commissioner&apos;s Office (ICO)</strong> — the UK&apos;s data protection regulator — at <a href="https://ico.org.uk" target="_blank" rel="noopener noreferrer">ico.org.uk</a>.</p>
 
             <h2>8. Data security</h2>
-            <p>We take appropriate technical and organisational measures to protect your personal data against unauthorised access, loss, or disclosure. Our CRM platform (GoHighLevel) maintains industry-standard security measures including encryption in transit and at rest.</p>
+            <p>We take appropriate technical and organisational measures to protect your personal data against unauthorised access, loss, or disclosure. Our CRM and communications platform maintains industry-standard security measures including encryption in transit and at rest.</p>
 
             <h2>9. Transfers outside the UK</h2>
-            <p>Some of our third-party service providers, including GoHighLevel and Google Analytics, may process data outside the UK. Where this occurs, we ensure appropriate safeguards are in place in accordance with UK GDPR requirements.</p>
+            <p>Some of our third-party service providers, including our CRM and communications platform and Google Analytics, may process data outside the UK. Where this occurs, we ensure appropriate safeguards are in place in accordance with UK GDPR requirements.</p>
 
             <h2>10. Changes to this policy</h2>
             <p>We may update this Privacy Policy from time to time. The date at the top of this page will always reflect the most recent version. We encourage you to review this policy periodically.</p>

--- a/app/register-interest/page.tsx
+++ b/app/register-interest/page.tsx
@@ -5,82 +5,54 @@ import { buildMetadata } from "@/lib/metadata";
 import { buildFAQSchema, type FAQItem } from "@/lib/faqSchema";
 import { SectionHeader } from "@/components/ui/SectionHeader";
 import { Eyebrow } from "@/components/ui/Eyebrow";
-import { Badge } from "@/components/ui/Badge";
 import { Accordion } from "@/components/ui/Accordion";
-import { ButtonLink } from "@/components/ui/Button";
 import { FadeUp } from "@/components/motion/FadeUp";
 import { StaggerChildren, StaggerItem } from "@/components/motion/StaggerChildren";
 import { RegisterInterestForm } from "@/components/forms/RegisterInterestForm";
 
 export const metadata: Metadata = buildMetadata({
-  title: "Join the UVH Supplier Network",
+  title: "Register Your Interest",
   description:
-    "Register your independent van or vehicle hire company to receive qualified B2B enquiries through the Unified Vehicle Hire network. Powered by RouleurCo.",
+    "See whether RouleurCo fits how your hire desk runs. Register your interest — no commitment, just a conversation about winning more of the hires that grow your year.",
   path: "/register-interest",
 });
 
-const whyJoin = [
-  {
-    title: "Qualified B2B enquiries matched to your fleet and location",
-    body: "Businesses come to UVH looking for a local hire operator. You only see enquiries that fit what you offer.",
-  },
-  {
-    title: "No aggregator fees — enquiries direct to your hire desk",
-    body: "We don&rsquo;t take a cut of the hire. Enquiries land in your inbox so you can quote and book on your own terms.",
-  },
-  {
-    title: "Backed by RouleurCo — so no enquiry goes cold",
-    body: "Every supplier in the network is powered by RouleurCo&rsquo;s automated follow-up, so qualified leads turn into confirmed hires.",
-  },
+const reassurance = [
+  "No hard sell — just a conversation",
+  "We'll show you how it maps to your hire desk",
+  "Built for independent UK rental operators",
 ];
 
-const whoFor = [
-  "Independent van hire, car &amp; van hire, or commercial vehicle rental operators",
-  "UK-based with an active hire desk and a fleet of 1–50 vehicles",
-  "Operators who can respond to qualified enquiries within 24 hours",
-];
-
-const whoNot = [
-  "National chains (Enterprise, Hertz, Europcar, Sixt, Avis, etc.)",
-  "Franchise operations of national brands",
-  "Peer-to-peer car sharing platforms",
-];
-
-const platformFeatures = [
+const whatNext = [
   {
-    title: "Enquiry Pipeline",
-    body: "Every UVH enquiry lands in one structured pipeline. No notepads, no scattered spreadsheets, no missed follow-ups.",
+    title: "We'll be in touch",
+    body: "Within two business days. A real person, not an automated drip — just a short note to find a time that suits.",
   },
   {
-    title: "Unified Inbox",
-    body: "SMS, email, Facebook, web chat — all messages in one place, linked to the customer&rsquo;s record.",
+    title: "A walk-through of how it works",
+    body: "We'll show you how RouleurCo captures every enquiry, tracks where your hires come from, and follows up until you get an answer.",
   },
   {
-    title: "Automated Follow-Up",
-    body: "Pre-built sequences fire automatically after every quote. Hires don&rsquo;t get forgotten on busy days.",
+    title: "An honest read on fit",
+    body: "If it's right for how your desk runs, brilliant. If it isn't, we'll tell you. There's nothing to sign and nothing to pay.",
   },
 ];
 
 const faqs: FAQItem[] = [
   {
-    question: "What is the Unified Vehicle Hire network?",
-    answer:
-      "Unified Vehicle Hire (UVH) is a B2B introduction service that connects businesses looking to hire vehicles with trusted local hire operators. We do the marketing, qualification and routing — you handle the hire. There&apos;s no commission on the hire itself.",
-  },
-  {
-    question: "How do I get listed as a hire operator?",
-    answer:
-      "Register your interest using the form above. We&apos;ll be in touch within 2 business days to walk through your fleet, locations, and the kinds of enquiries you can handle — then add you to the supplier network for your area.",
-  },
-  {
     question: "What is RouleurCo?",
     answer:
-      "RouleurCo is the sales and automation platform that sits behind every UVH supplier. It captures enquiries, sends quotes, automates follow-ups, and tracks every hire from first contact to confirmed booking. It&apos;s how we make sure UVH enquiries actually convert into hires.",
+      "RouleurCo is a sales and automation platform built specifically for independent vehicle rental companies. It sits alongside the software that runs your fleet and the inbox that holds your emails, and it runs the commercial side — capturing every enquiry, tracking where your hires come from, and making sure quotes get followed up until you get an answer.",
   },
   {
-    question: "Is there a cost to join?",
+    question: "What happens after I register?",
     answer:
-      "There&apos;s no cost to register your interest or be considered for the network. The RouleurCo platform itself is a paid subscription with a founding operator rate for the first 10 companies that join. We&apos;ll walk through pricing in your initial conversation — no surprises.",
+      "We'll be in touch within two business days for a short, no-pressure conversation. We'll show you how it works and give you an honest read on whether it's a fit for how your hire desk runs.",
+  },
+  {
+    question: "Is there any commitment?",
+    answer:
+      "None. Registering your interest just starts a conversation. There's nothing to sign and nothing to pay.",
   },
 ];
 
@@ -102,35 +74,35 @@ export default function RegisterInterestPage() {
           <div className="grid gap-12 lg:grid-cols-[1.1fr_1fr] lg:gap-16 items-start">
             <div className="flex flex-col gap-6 max-w-xl">
               <FadeUp>
-                <Eyebrow variant="white">For independent hire operators</Eyebrow>
+                <Eyebrow variant="white">Register your interest</Eyebrow>
               </FadeUp>
               <FadeUp delay={0.05}>
                 <h1 className="font-display text-4xl sm:text-5xl lg:text-6xl font-bold leading-[1.05] tracking-tight text-balance">
-                  Get qualified B2B hire enquiries for your area
+                  See if it&apos;s a fit for how your hire desk runs
                 </h1>
               </FadeUp>
               <FadeUp delay={0.1}>
                 <p className="text-lg sm:text-xl text-white/75 leading-relaxed text-balance">
-                  Unified Vehicle Hire connects businesses with trusted local hire operators. Register your interest to join the supplier network — and discover the platform behind it.
+                  RouleurCo helps independent rental companies win more of the right hires — especially the long-term ones that steady the year. Register your interest and we&apos;ll show you how it works. No commitment.
                 </p>
               </FadeUp>
               <FadeUp delay={0.15}>
                 <div className="mt-4 flex flex-col gap-3">
-                  <BulletProof text="No aggregator fees on the hire itself" />
-                  <BulletProof text="Enquiries direct to your hire desk" />
-                  <BulletProof text="We&rsquo;ll respond within 2 business days" />
+                  {reassurance.map((text) => (
+                    <BulletProof key={text} text={text} />
+                  ))}
                 </div>
               </FadeUp>
             </div>
 
             <FadeUp delay={0.1}>
               <div className="rounded-card bg-white p-7 sm:p-8 shadow-2xl ring-1 ring-black/5">
-                <Eyebrow>Register Your Interest</Eyebrow>
+                <Eyebrow>Register your interest</Eyebrow>
                 <h2 className="mt-3 font-display text-xl sm:text-2xl font-bold text-brand-navy">
-                  Tell us about your hire desk
+                  Interested? Tell us where to reach you.
                 </h2>
                 <p className="mt-1 text-sm text-brand-text-2">
-                  Takes under a minute. We&apos;ll be in touch within 2 business days.
+                  No commitment. We&apos;ll show you how it works and whether it&apos;s a fit for how your hire desk runs.
                 </p>
                 <div className="mt-6">
                   <RegisterInterestForm />
@@ -141,142 +113,31 @@ export default function RegisterInterestPage() {
         </div>
       </section>
 
-      {/* WHY JOIN */}
+      {/* WHAT HAPPENS NEXT */}
       <section className="bg-white py-20 sm:py-24">
         <div className="container-rc">
           <SectionHeader
-            eyebrow="Why join the network"
-            heading="Built so qualified enquiries actually convert."
-            lead="UVH brings the demand. RouleurCo makes sure it doesn&rsquo;t fall through the cracks at your hire desk."
+            eyebrow="What happens next"
+            heading="A conversation, not a sales pitch."
+            lead="We're in a quiet build phase, working with a small group of operators. Registering your interest just puts you on the list to see it."
           />
           <StaggerChildren className="mt-12 grid gap-5 md:grid-cols-3">
-            {whyJoin.map((w) => (
+            {whatNext.map((w, i) => (
               <StaggerItem key={w.title}>
                 <div className="h-full rounded-card border border-brand-mid bg-white p-7">
-                  <span className="inline-flex size-10 items-center justify-center rounded-lg bg-brand-blue text-white">
-                    <svg className="size-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-                      <polyline points="20 6 9 17 4 12" />
-                    </svg>
+                  <span className="inline-flex size-10 items-center justify-center rounded-lg bg-brand-blue text-white font-display font-bold">
+                    {i + 1}
                   </span>
                   <h3 className="mt-4 font-display text-lg font-bold text-brand-navy">
                     {w.title}
                   </h3>
-                  <p
-                    className="mt-2 text-sm text-brand-text-2 leading-relaxed"
-                    dangerouslySetInnerHTML={{ __html: w.body }}
-                  />
+                  <p className="mt-2 text-sm text-brand-text-2 leading-relaxed">
+                    {w.body}
+                  </p>
                 </div>
               </StaggerItem>
             ))}
           </StaggerChildren>
-        </div>
-      </section>
-
-      {/* WHO IT'S FOR */}
-      <section className="bg-brand-lightbg py-20 sm:py-24">
-        <div className="container-rc">
-          <SectionHeader
-            eyebrow="Who this is for"
-            heading="Independent UK hire operators with an active fleet."
-          />
-          <div className="mt-12 grid gap-6 lg:grid-cols-2 max-w-4xl mx-auto">
-            <FadeUp>
-              <div className="rounded-card border border-brand-green/30 bg-brand-green/5 p-7">
-                <Badge tone="green">Good fit</Badge>
-                <ul className="mt-5 flex flex-col gap-3">
-                  {whoFor.map((item) => (
-                    <li key={item} className="flex gap-3 items-start text-sm text-brand-text-2">
-                      <span className="mt-0.5 inline-flex size-5 shrink-0 items-center justify-center rounded-full bg-brand-green/15 text-brand-green text-xs font-bold">
-                        ✓
-                      </span>
-                      <span dangerouslySetInnerHTML={{ __html: item }} />
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            </FadeUp>
-            <FadeUp delay={0.1}>
-              <div className="rounded-card border border-brand-red/30 bg-brand-red/5 p-7">
-                <Badge tone="red">Not a fit</Badge>
-                <ul className="mt-5 flex flex-col gap-3">
-                  {whoNot.map((item) => (
-                    <li key={item} className="flex gap-3 items-start text-sm text-brand-text-2">
-                      <span className="mt-0.5 inline-flex size-5 shrink-0 items-center justify-center rounded-full bg-brand-red/15 text-brand-red text-xs font-bold">
-                        ✕
-                      </span>
-                      <span>{item}</span>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            </FadeUp>
-          </div>
-        </div>
-      </section>
-
-      {/* UVH CONTEXT */}
-      <section className="bg-white py-20 sm:py-24">
-        <div className="container-rc max-w-3xl">
-          <FadeUp>
-            <Eyebrow>About Unified Vehicle Hire</Eyebrow>
-            <h2 className="mt-4 font-display text-3xl sm:text-4xl font-bold text-brand-navy leading-[1.15] text-balance">
-              The introduction service connecting UK businesses with local hire operators.
-            </h2>
-            <p className="mt-5 text-lg text-brand-text-2 leading-relaxed">
-              Unified Vehicle Hire (UVH) is a B2B introduction service that matches businesses needing to hire vehicles with trusted local hire operators across the UK. We do the marketing, qualification and routing — operators handle the hire on their own terms.
-            </p>
-            <p className="mt-4 text-brand-text-2 leading-relaxed">
-              No commission on the hire. No long-form aggregator listings. Just a clean route from business demand to local supply.
-            </p>
-            <div className="mt-8">
-              <a
-                href="https://unifiedvehiclehire.co.uk"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 font-display font-semibold text-brand-blue hover:text-brand-blue-hover underline underline-offset-4"
-              >
-                Visit unifiedvehiclehire.co.uk
-                <svg className="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                  <path d="M7 17L17 7M7 7h10v10" />
-                </svg>
-              </a>
-            </div>
-          </FadeUp>
-        </div>
-      </section>
-
-      {/* ROULEURCO INTRO */}
-      <section className="bg-brand-navy py-20 sm:py-24 text-white">
-        <div className="container-rc">
-          <SectionHeader
-            eyebrow="The platform behind the network"
-            heading="RouleurCo makes sure UVH enquiries actually convert."
-            lead="Every supplier in the network runs on RouleurCo — a sales and automation platform pre-configured for vehicle rental."
-            variant="dark"
-          />
-          <StaggerChildren className="mt-12 grid gap-5 md:grid-cols-3">
-            {platformFeatures.map((p) => (
-              <StaggerItem key={p.title}>
-                <div className="h-full rounded-card border border-white/10 bg-white/[0.04] p-7">
-                  <h3 className="font-display text-lg font-bold text-white">{p.title}</h3>
-                  <p
-                    className="mt-3 text-sm text-white/70 leading-relaxed"
-                    dangerouslySetInnerHTML={{ __html: p.body }}
-                  />
-                </div>
-              </StaggerItem>
-            ))}
-          </StaggerChildren>
-          <FadeUp delay={0.2}>
-            <div className="mt-12 flex flex-wrap justify-center gap-3">
-              <ButtonLink href="/how-it-works" variant="primary" size="lg">
-                See How It Works
-              </ButtonLink>
-              <ButtonLink href="/features" variant="ghost-white" size="lg">
-                Explore the Platform →
-              </ButtonLink>
-            </div>
-          </FadeUp>
         </div>
       </section>
 
@@ -284,14 +145,14 @@ export default function RegisterInterestPage() {
       <section className="bg-brand-lightbg py-20 sm:py-24">
         <div className="container-rc max-w-3xl">
           <SectionHeader
-            eyebrow="Common Questions"
-            heading="Quick answers before you register."
+            eyebrow="Common questions"
+            heading="A couple of quick answers before you register."
           />
           <div className="mt-12">
             <Accordion items={faqs} defaultOpen={0} />
           </div>
           <p className="mt-8 text-center text-sm text-brand-muted">
-            Still got a question? <Link href="/contact" className="text-brand-blue underline">Get in touch directly.</Link>
+            Prefer to ask first? <Link href="/contact" className="text-brand-blue underline">Get in touch directly.</Link>
           </p>
         </div>
       </section>
@@ -314,10 +175,7 @@ function BulletProof({ text }: { text: string }) {
           <polyline points="20 6 9 17 4 12" />
         </svg>
       </span>
-      <span
-        className="text-sm text-white/85"
-        dangerouslySetInnerHTML={{ __html: text }}
-      />
+      <span className="text-sm text-white/85">{text}</span>
     </div>
   );
 }

--- a/components/forms/RegisterInterestForm.tsx
+++ b/components/forms/RegisterInterestForm.tsx
@@ -48,10 +48,10 @@ export function RegisterInterestForm() {
           </svg>
         </span>
         <h3 className="mt-5 font-display text-2xl font-bold text-brand-navy">
-          Thanks — we&apos;ve got it.
+          Thanks — we&apos;ve got your details.
         </h3>
         <p className="mt-3 text-brand-text-2 leading-relaxed">
-          We&apos;ll be in touch within 2 business days. No hard sell — just a conversation about whether the UVH network is a fit for your hire desk.
+          We&apos;ll be in touch within two business days. No hard sell — just a conversation about whether it&apos;s a fit for how your hire desk runs.
         </p>
       </div>
     );
@@ -79,7 +79,7 @@ export function RegisterInterestForm() {
         label="Location / Town"
         required
         autoComplete="address-level2"
-        helper="So we can match enquiries from the right area."
+        helper="So we know roughly where you operate."
       />
 
       <div className="flex flex-col gap-2">
@@ -143,11 +143,11 @@ export function RegisterInterestForm() {
         disabled={status === "submitting"}
         className="inline-flex items-center justify-center gap-2 rounded-btn bg-brand-blue px-6 py-3 font-display font-semibold text-white hover:bg-brand-blue-hover disabled:opacity-60 disabled:cursor-not-allowed min-h-[48px] transition-colors"
       >
-        {status === "submitting" ? "Submitting…" : "Register My Interest"}
+        {status === "submitting" ? "Submitting…" : "Register my interest"}
       </button>
 
       <p className="text-sm text-brand-muted text-center">
-        We&apos;ll be in touch within 2 business days. No hard sell — just a conversation.
+        We&apos;ll be in touch within two business days. No hard sell — just a conversation.
       </p>
     </form>
   );

--- a/components/layout/NavBar.tsx
+++ b/components/layout/NavBar.tsx
@@ -43,15 +43,6 @@ export function NavBar() {
 
         <nav className="hidden lg:flex items-center gap-1" aria-label="Primary">
           <Link
-            href="/lead-generation"
-            className={cn(
-              "px-3 py-2 text-sm font-display font-semibold text-brand-text-2 hover:text-brand-navy rounded-md",
-              pathname === "/lead-generation" && "text-brand-navy"
-            )}
-          >
-            Lead Generation
-          </Link>
-          <Link
             href="/how-it-works"
             className={cn(
               "px-3 py-2 text-sm font-display font-semibold text-brand-text-2 hover:text-brand-navy rounded-md",
@@ -114,7 +105,7 @@ export function NavBar() {
             )}
           </div>
 
-          {primaryNav.slice(3).map((item) => (
+          {primaryNav.slice(2).map((item) => (
             <Link
               key={item.href}
               href={item.href}

--- a/components/layout/nav-config.ts
+++ b/components/layout/nav-config.ts
@@ -17,21 +17,22 @@ export const featureLinks: NavItem[] = [
   { label: "Mobile & Desktop App", href: "/features/apps", description: "iOS, Android, Mac, Windows" },
 ];
 
+// Order matters: index 0 renders as a plain desktop link, index 1 ("Features")
+// renders as the mega-dropdown, and everything from index 2 onwards renders
+// after the dropdown. The mobile drawer renders the full list.
 export const primaryNav: NavItem[] = [
-  { label: "Lead Generation", href: "/lead-generation" },
   { label: "How It Works", href: "/how-it-works" },
   { label: "Features", href: "/features" },
-  { label: "Pricing", href: "/pricing" },
+  { label: "Growth Check", href: "/growth-check" },
   { label: "Compare", href: "/compare" },
   { label: "About", href: "/about" },
 ];
 
 export const footerNav = {
   platform: [
-    { label: "Lead Generation", href: "/lead-generation" },
     { label: "How It Works", href: "/how-it-works" },
     { label: "Features", href: "/features" },
-    { label: "Pricing", href: "/pricing" },
+    { label: "Growth Check", href: "/growth-check" },
     { label: "Compare", href: "/compare" },
   ],
   company: [

--- a/components/layout/nav-config.ts
+++ b/components/layout/nav-config.ts
@@ -7,6 +7,8 @@ export type NavItem = {
 export const featureLinks: NavItem[] = [
   { label: "Enquiry Pipelines", href: "/features/pipelines", description: "Capture & track every hire" },
   { label: "Unified Inbox", href: "/features/unified-inbox", description: "SMS, email & social in one place" },
+  { label: "Enquiry Source Tracking", href: "/features/enquiry-sources", description: "See where your hires come from" },
+  { label: "Quote Follow-Up", href: "/features/quote-follow-up", description: "Chase every quote automatically" },
   { label: "Missed Call Text-Back", href: "/features/missed-call", description: "Auto-SMS on missed calls" },
   { label: "Payments & Recovery", href: "/features/payments", description: "Stripe / GoCardless + retries" },
   { label: "Enquiry Qualification", href: "/features/lead-qualification", description: "Lead scoring & time-waster filter" },

--- a/components/sections/home/CeilingSection.tsx
+++ b/components/sections/home/CeilingSection.tsx
@@ -1,0 +1,25 @@
+import { SectionHeader } from "@/components/ui/SectionHeader";
+import { FadeUp } from "@/components/motion/FadeUp";
+
+export function CeilingSection() {
+  return (
+    <section className="bg-white py-20 sm:py-24">
+      <div className="container-rc">
+        <SectionHeader
+          eyebrow="The ceiling"
+          heading="Daily hire is a brilliant business. It's also capped."
+        />
+        <FadeUp delay={0.1}>
+          <div className="mx-auto mt-8 max-w-3xl flex flex-col gap-5 text-lg text-brand-text-2 leading-relaxed">
+            <p>
+              You can only fit so many vehicles on the yard, and only turn each one around so many times a week. Through the peak you&apos;ve barely got a van available. Through the trough the car park&apos;s full and those assets are sitting there — still costing you finance, insurance and depreciation, earning nothing.
+            </p>
+            <p className="font-display text-xl font-bold text-brand-navy">
+              You can&apos;t admin your way past that ceiling. The way past it is changing the mix.
+            </p>
+          </div>
+        </FadeUp>
+      </div>
+    </section>
+  );
+}

--- a/components/sections/home/CommercialLayerSection.tsx
+++ b/components/sections/home/CommercialLayerSection.tsx
@@ -1,0 +1,64 @@
+import { Eyebrow } from "@/components/ui/Eyebrow";
+import { CheckList } from "@/components/ui/CheckList";
+import { FadeUp } from "@/components/motion/FadeUp";
+
+export function CommercialLayerSection() {
+  return (
+    <section className="bg-white py-20 sm:py-24">
+      <div className="container-rc">
+        <div className="mx-auto max-w-3xl text-center">
+          <FadeUp>
+            <Eyebrow>The commercial layer</Eyebrow>
+            <h2 className="mt-4 font-display text-3xl sm:text-4xl lg:text-5xl font-bold text-brand-navy leading-[1.1] text-balance">
+              RouleurCo isn&apos;t a fleet system, and it isn&apos;t trying to replace one.
+            </h2>
+            <p className="mt-5 text-lg text-brand-text-2 leading-relaxed">
+              Your fleet software runs the vehicles. Your inbox holds the emails. Neither one is making sure the long-term enquiry gets chased, or telling you which channel your hires come from. That&apos;s the commercial side — and it&apos;s the half of the business that decides whether you grow.
+            </p>
+          </FadeUp>
+        </div>
+
+        <div className="mt-12 grid gap-5 lg:grid-cols-2 max-w-4xl mx-auto">
+          <FadeUp>
+            <div className="h-full rounded-card border border-brand-mid bg-brand-lightbg p-7">
+              <h3 className="font-display text-lg font-bold text-brand-navy">
+                What you already have
+              </h3>
+              <p className="mt-1 text-sm text-brand-muted">Keep it — RouleurCo sits alongside it.</p>
+              <CheckList
+                className="mt-5"
+                items={[
+                  "Fleet software that runs the vehicles",
+                  "An inbox that holds the emails",
+                ]}
+              />
+            </div>
+          </FadeUp>
+          <FadeUp delay={0.1}>
+            <div className="h-full rounded-card border border-brand-blue bg-white p-7 ring-1 ring-brand-blue/20 shadow-lg">
+              <h3 className="font-display text-lg font-bold text-brand-navy">
+                What RouleurCo runs — the commercial layer
+              </h3>
+              <p className="mt-1 text-sm text-brand-muted">The part that wins the work.</p>
+              <CheckList
+                className="mt-5"
+                items={[
+                  "Every enquiry captured and chased",
+                  "Every quote followed up until you get an answer",
+                  "Every hire's source tracked, so you grow what works",
+                ]}
+              />
+            </div>
+          </FadeUp>
+        </div>
+
+        <FadeUp delay={0.15}>
+          <p className="mt-12 text-center font-display text-xl sm:text-2xl font-bold text-brand-navy text-balance max-w-2xl mx-auto">
+            Keep what runs your fleet.{" "}
+            <span className="text-brand-blue">RouleurCo runs the part that wins the work.</span>
+          </p>
+        </FadeUp>
+      </div>
+    </section>
+  );
+}

--- a/components/sections/home/CompetitionSection.tsx
+++ b/components/sections/home/CompetitionSection.tsx
@@ -1,0 +1,31 @@
+import { SectionHeader } from "@/components/ui/SectionHeader";
+import { FadeUp } from "@/components/motion/FadeUp";
+
+export function CompetitionSection() {
+  return (
+    <section className="bg-white py-20 sm:py-24">
+      <div className="container-rc">
+        <SectionHeader
+          eyebrow="The real competition"
+          heading="You're not really competing with the unit down the road."
+        />
+        <FadeUp delay={0.1}>
+          <div className="mx-auto mt-8 max-w-3xl flex flex-col gap-5 text-lg text-brand-text-2 leading-relaxed">
+            <p>
+              You&apos;re up against the national networks — the ones with the ad budgets, the brand recall and the fleet depth. You won&apos;t out-spend them. You don&apos;t need to.
+            </p>
+            <p>
+              What they can&apos;t do is pick up fast, know the customer, and follow up like it matters. At their scale, the desk is slow, scripted and faceless.
+            </p>
+            <p className="font-display text-xl font-bold text-brand-navy">
+              That&apos;s the ground you win on.
+            </p>
+            <p>
+              RouleurCo gives you the structure of a big operation — nothing missed, every enquiry chased — while you stay as fast and personal as only an independent can be.
+            </p>
+          </div>
+        </FadeUp>
+      </div>
+    </section>
+  );
+}

--- a/components/sections/home/HomeHero.tsx
+++ b/components/sections/home/HomeHero.tsx
@@ -19,37 +19,43 @@ export function HomeHero() {
         <div className="grid gap-12 lg:grid-cols-[1.05fr_1fr] lg:gap-16 items-center">
           <div className="flex flex-col gap-6 max-w-xl">
             <FadeUp>
-              <Eyebrow variant="white">Built for vehicle rental</Eyebrow>
+              <Eyebrow variant="white">Grow your hire desk</Eyebrow>
             </FadeUp>
             <FadeUp delay={0.05}>
               <h1 className="font-display font-bold text-4xl sm:text-5xl lg:text-6xl leading-[1.05] tracking-tight text-balance">
-                Sales & automation built for{" "}
-                <em className="not-italic text-brand-blue">rental companies</em>
+                You want to <em className="not-italic text-brand-blue">grow</em>.
+                <br />
+                You already know it&apos;s hard.
               </h1>
             </FadeUp>
             <FadeUp delay={0.1}>
               <p className="text-lg sm:text-xl text-white/75 leading-relaxed text-balance">
-                Capture every enquiry. Send quotes faster. Follow up automatically. Convert more hires — without adding admin.
+                For an independent rental company, growth isn&apos;t about working harder — your desk is already flat out. It&apos;s about winning more of the right hires, so your vehicles earn year-round and adding to the fleet stops feeling like a gamble.
               </p>
             </FadeUp>
             <FadeUp delay={0.15}>
+              <p className="text-lg font-display font-semibold text-white text-balance">
+                RouleurCo is built to help you do exactly that.
+              </p>
+            </FadeUp>
+            <FadeUp delay={0.2}>
               <div className="flex flex-wrap gap-3 mt-2">
-                <ButtonLink href="/contact#founding" variant="primary" size="lg">
-                  Join Founding Operators
+                <ButtonLink href="/register-interest" variant="primary" size="lg">
+                  Register your interest
                   <span aria-hidden="true">→</span>
                 </ButtonLink>
                 <ButtonLink href="/how-it-works" variant="ghost-white" size="lg">
-                  See How It Works
+                  See how it works
                 </ButtonLink>
               </div>
             </FadeUp>
-            <FadeUp delay={0.2}>
+            <FadeUp delay={0.25}>
               <div className="mt-6 flex flex-wrap gap-x-8 gap-y-4 pt-6 border-t border-white/10">
-                <ProofStat strong="10 spots" label="Founding operators" />
+                <ProofStat strong="Capture" label="every enquiry, from everywhere" />
                 <span className="hidden sm:block h-10 w-px bg-white/10 self-center" />
-                <ProofStat strong="84%" label="LCV customers are business users" />
+                <ProofStat strong="Follow up" label="until someone replies" />
                 <span className="hidden sm:block h-10 w-px bg-white/10 self-center" />
-                <ProofStat strong="1 system" label="Everything in one place" />
+                <ProofStat strong="Convert" label="more of the hires that grow your year" />
               </div>
             </FadeUp>
           </div>
@@ -65,7 +71,7 @@ export function HomeHero() {
 
 function ProofStat({ strong, label }: { strong: string; label: string }) {
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-col max-w-[12rem]">
       <strong className="font-display text-lg font-bold text-white">{strong}</strong>
       <span className="text-xs text-white/55">{label}</span>
     </div>

--- a/components/sections/home/LeverSection.tsx
+++ b/components/sections/home/LeverSection.tsx
@@ -1,0 +1,45 @@
+import { Eyebrow } from "@/components/ui/Eyebrow";
+import { CheckList } from "@/components/ui/CheckList";
+import { FadeUp } from "@/components/motion/FadeUp";
+
+export function LeverSection() {
+  return (
+    <section className="bg-brand-lightbg py-20 sm:py-24">
+      <div className="container-rc">
+        <div className="grid gap-12 lg:grid-cols-2 lg:gap-16 items-center">
+          <FadeUp>
+            <div className="max-w-xl">
+              <Eyebrow>The lever</Eyebrow>
+              <h2 className="mt-4 font-display text-3xl sm:text-4xl lg:text-5xl font-bold text-brand-navy leading-[1.1] text-balance">
+                More long-term hire is what steadies the year.
+              </h2>
+              <p className="mt-5 text-lg text-brand-text-2 leading-relaxed">
+                Every vehicle you move onto a longer hire is one that&apos;s no longer sitting idle in the quiet months. The troughs lift. Your average utilisation climbs. And once your fleet earns more reliably across the year, adding vehicles stops being a risk and starts being a plan.
+              </p>
+              <p className="mt-4 text-brand-text-2 leading-relaxed">
+                You probably win some long-term hires already. The question is whether you&apos;re winning enough of them — and whether the enquiries that could become long-term ones are being chased hard enough to land.
+              </p>
+            </div>
+          </FadeUp>
+
+          <FadeUp delay={0.1}>
+            <div className="rounded-card border border-brand-mid bg-white p-8 shadow-sm">
+              <h3 className="font-display text-xl font-bold text-brand-navy">
+                What moving the mix does
+              </h3>
+              <CheckList
+                className="mt-6"
+                items={[
+                  "Lifts the troughs in the quiet months",
+                  "Climbs your average year-round utilisation",
+                  "Turns fleet growth from a gamble into a plan",
+                  "Makes every long-term enquiry worth chasing hard",
+                ]}
+              />
+            </div>
+          </FadeUp>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/sections/home/MechanismsSection.tsx
+++ b/components/sections/home/MechanismsSection.tsx
@@ -1,0 +1,79 @@
+import Link from "next/link";
+import { SectionHeader } from "@/components/ui/SectionHeader";
+import { StaggerChildren, StaggerItem } from "@/components/motion/StaggerChildren";
+
+type Mechanism = {
+  title: string;
+  body: string;
+  href?: string;
+  linkLabel?: string;
+};
+
+// Each mechanism links to its matching feature page. Two of the four have no
+// dedicated feature page yet: "Know where your work comes from" (reporting /
+// source-tracking) has none and is intentionally left without a link; "Follow up
+// until someone replies" points at Missed Call Text-Back as the nearest
+// follow-up-automation page until a dedicated one exists.
+const mechanisms: Mechanism[] = [
+  {
+    title: "Capture every enquiry, from everywhere.",
+    body: "Phone, email, website, Facebook, a missed call at 9pm — all of them, in one inbox, the moment they land.",
+    href: "/features/unified-inbox",
+    linkLabel: "See the unified inbox",
+  },
+  {
+    title: "Know where your work comes from.",
+    body: "See whether your hires come from Google, Facebook or the phone, so you can lean into what's converting.",
+  },
+  {
+    title: "Follow up until someone replies.",
+    body: "Every quote chased automatically, across channels, until you get an answer.",
+    href: "/features/missed-call",
+    linkLabel: "See follow-up automation",
+  },
+  {
+    title: "Convert more of the hires that change your year.",
+    body: "A structured desk turns more enquiries — especially the long-term ones — into booked, earning vehicles.",
+    href: "/features/pipelines",
+    linkLabel: "See enquiry pipelines",
+  },
+];
+
+export function MechanismsSection() {
+  return (
+    <section className="bg-brand-navy py-20 sm:py-24 text-white">
+      <div className="container-rc">
+        <SectionHeader
+          eyebrow="How RouleurCo does it"
+          heading="The commercial side of a growing hire desk."
+          lead="Four moving parts, each built to win you more of the work — and more of the long-term work in particular."
+          variant="dark"
+        />
+
+        <StaggerChildren className="mt-12 grid gap-5 sm:grid-cols-2">
+          {mechanisms.map((m) => (
+            <StaggerItem key={m.title}>
+              <div className="flex h-full flex-col rounded-card border border-white/10 bg-white/[0.04] p-7">
+                <h3 className="font-display text-lg font-bold text-white">
+                  {m.title}
+                </h3>
+                <p className="mt-3 text-sm text-white/70 leading-relaxed">
+                  {m.body}
+                </p>
+                {m.href && (
+                  <Link
+                    href={m.href}
+                    className="mt-5 inline-flex items-center gap-1.5 text-sm font-display font-semibold text-brand-blue hover:text-white"
+                  >
+                    {m.linkLabel}
+                    <span aria-hidden="true">→</span>
+                  </Link>
+                )}
+              </div>
+            </StaggerItem>
+          ))}
+        </StaggerChildren>
+      </div>
+    </section>
+  );
+}

--- a/components/sections/home/MechanismsSection.tsx
+++ b/components/sections/home/MechanismsSection.tsx
@@ -9,11 +9,7 @@ type Mechanism = {
   linkLabel?: string;
 };
 
-// Each mechanism links to its matching feature page. Two of the four have no
-// dedicated feature page yet: "Know where your work comes from" (reporting /
-// source-tracking) has none and is intentionally left without a link; "Follow up
-// until someone replies" points at Missed Call Text-Back as the nearest
-// follow-up-automation page until a dedicated one exists.
+// Each mechanism links to its matching feature page.
 const mechanisms: Mechanism[] = [
   {
     title: "Capture every enquiry, from everywhere.",
@@ -24,12 +20,14 @@ const mechanisms: Mechanism[] = [
   {
     title: "Know where your work comes from.",
     body: "See whether your hires come from Google, Facebook or the phone, so you can lean into what's converting.",
+    href: "/features/enquiry-sources",
+    linkLabel: "See enquiry source tracking",
   },
   {
     title: "Follow up until someone replies.",
     body: "Every quote chased automatically, across channels, until you get an answer.",
-    href: "/features/missed-call",
-    linkLabel: "See follow-up automation",
+    href: "/features/quote-follow-up",
+    linkLabel: "See quote follow-up",
   },
   {
     title: "Convert more of the hires that change your year.",

--- a/components/sections/home/RegisterInterestCTA.tsx
+++ b/components/sections/home/RegisterInterestCTA.tsx
@@ -1,0 +1,40 @@
+import { FadeUp } from "@/components/motion/FadeUp";
+import { Eyebrow } from "@/components/ui/Eyebrow";
+import { RegisterInterestForm } from "@/components/forms/RegisterInterestForm";
+
+export function RegisterInterestCTA() {
+  return (
+    <section id="register-interest" className="relative overflow-hidden bg-brand-navy py-20 sm:py-24 text-white">
+      <div
+        className="pointer-events-none absolute inset-0 opacity-[0.06]"
+        style={{
+          backgroundImage:
+            "linear-gradient(to right, white 1px, transparent 1px), linear-gradient(to bottom, white 1px, transparent 1px)",
+          backgroundSize: "48px 48px",
+        }}
+        aria-hidden="true"
+      />
+      <div className="container-rc relative">
+        <div className="grid gap-12 lg:grid-cols-[1fr_1fr] lg:gap-16 items-center">
+          <FadeUp>
+            <div className="max-w-xl">
+              <Eyebrow variant="white">Register your interest</Eyebrow>
+              <h2 className="mt-4 font-display text-3xl sm:text-4xl lg:text-5xl font-bold leading-[1.1] text-balance">
+                Interested? Tell us where to reach you.
+              </h2>
+              <p className="mt-5 text-lg text-white/75 leading-relaxed text-balance">
+                No commitment. We&apos;ll show you how it works and whether it&apos;s a fit for how your hire desk runs.
+              </p>
+            </div>
+          </FadeUp>
+
+          <FadeUp delay={0.1}>
+            <div className="rounded-card bg-white p-7 sm:p-8 shadow-2xl ring-1 ring-black/5">
+              <RegisterInterestForm />
+            </div>
+          </FadeUp>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/sections/home/ResultSection.tsx
+++ b/components/sections/home/ResultSection.tsx
@@ -1,0 +1,50 @@
+import { SectionHeader } from "@/components/ui/SectionHeader";
+import { FadeUp } from "@/components/motion/FadeUp";
+import { StaggerChildren, StaggerItem } from "@/components/motion/StaggerChildren";
+
+const results = [
+  {
+    title: "Steadier troughs",
+    body: "The quiet months stop hurting, because more of the fleet is already earning.",
+  },
+  {
+    title: "Higher year-round utilisation",
+    body: "Your average climbs as long-term hires fill the gaps daily work leaves behind.",
+  },
+  {
+    title: "Confidence to grow the fleet",
+    body: "Adding vehicles becomes a plan, not a gamble — because you know they'll earn.",
+  },
+];
+
+export function ResultSection() {
+  return (
+    <section className="bg-brand-lightbg py-20 sm:py-24">
+      <div className="container-rc">
+        <SectionHeader
+          eyebrow="The result"
+          heading="What growing actually looks like."
+        />
+        <StaggerChildren className="mt-12 grid gap-5 md:grid-cols-3">
+          {results.map((r) => (
+            <StaggerItem key={r.title}>
+              <div className="h-full rounded-card border border-brand-mid bg-white p-7">
+                <h3 className="font-display text-lg font-bold text-brand-navy">
+                  {r.title}
+                </h3>
+                <p className="mt-2 text-sm text-brand-text-2 leading-relaxed">
+                  {r.body}
+                </p>
+              </div>
+            </StaggerItem>
+          ))}
+        </StaggerChildren>
+        <FadeUp delay={0.15}>
+          <p className="mt-12 text-center font-display text-xl sm:text-2xl font-bold text-brand-navy text-balance max-w-2xl mx-auto">
+            More of the enquiries you already get — and more of the ones you actually want.
+          </p>
+        </FadeUp>
+      </div>
+    </section>
+  );
+}

--- a/lib/ghl.ts
+++ b/lib/ghl.ts
@@ -19,6 +19,14 @@ export async function submitToGHL(data: RegisterInterestPayload): Promise<true> 
     body: JSON.stringify({
       ...data,
       source: "rouleurco-register-interest",
+      // Hints for the receiving GHL inbound-webhook workflow. NOTE: there is no
+      // "New Enquiry" stage in GHL today — the entry stage is "New Lead" (e.g. the
+      // Marketing Pipeline). The workflow should file this contact at that entry
+      // stage and apply the tags below so website interest stays distinct from
+      // live hire enquiries. No nurture sequence is attached yet (lead gen is
+      // paused) — capture and notify only.
+      pipelineStage: "New Lead",
+      tags: ["Source — Web Form", "Interest — Website"],
       timestamp: new Date().toISOString(),
     }),
   });

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -5,7 +5,9 @@ module.exports = {
   generateIndexSitemap: false,
 
   // Pages we deliberately keep out of search engines.
-  exclude: ["/thank-you", "/404"],
+  // /pricing and /lead-generation are parked (they redirect to /register-interest)
+  // while lead generation is paused — keep them out of the sitemap.
+  exclude: ["/thank-you", "/404", "/pricing", "/lead-generation"],
 
   changefreq: "weekly",
   priority: 0.7,
@@ -15,7 +17,7 @@ module.exports = {
       {
         userAgent: "*",
         allow: "/",
-        disallow: ["/thank-you", "/api/"],
+        disallow: ["/thank-you", "/api/", "/pricing", "/lead-generation"],
       },
     ],
     additionalSitemaps: [
@@ -25,8 +27,8 @@ module.exports = {
 
   // Per-URL priority hints — flagship pages get a slight boost.
   transform: async (config, path) => {
-    const flagship = ["/", "/lead-generation", "/register-interest"];
-    const highValue = ["/pricing", "/features", "/how-it-works", "/compare", "/contact"];
+    const flagship = ["/", "/register-interest"];
+    const highValue = ["/growth-check", "/features", "/how-it-works", "/compare", "/contact"];
 
     let priority = 0.6;
     if (flagship.includes(path)) priority = 1.0;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,18 @@ const nextConfig = {
   poweredByHeader: false,
   reactStrictMode: true,
 
+  // Parked pages — lead generation is paused during the stealth/brand-awareness
+  // phase, so the pricing and (UVH) lead-generation pages are unpublished by
+  // redirecting them to the register-interest form. The page files are kept
+  // intact under app/ so these can be switched back on by removing the redirect.
+  // `permanent: false` (307) keeps them recoverable without poisoning caches.
+  async redirects() {
+    return [
+      { source: "/pricing", destination: "/register-interest", permanent: false },
+      { source: "/lead-generation", destination: "/register-interest", permanent: false },
+    ];
+  },
+
   async headers() {
     return [
       {


### PR DESCRIPTION
Re-messages the whole site around the growth pillars, moves it into a stealth / brand-awareness phase (lead generation paused), and completes the feature-page mapping. **All existing styling preserved** — built entirely from the existing components, brand tokens, and feature-page template.

## Highlights
- **Home** rebuilt around the growth narrative: ceiling → long-term hire (the lever) → real competition → four mechanisms → commercial layer → result → register interest.
- **How It Works** restructured around the four mechanisms + the commercial-layer positioning block.
- **Growth Check** — new `/growth-check` page (the hire-desk checklist), added to nav + footer.
- **Register-interest** rebuilt from the old "Join the UVH Supplier Network" page into a clean RouleurCo soft-interest page. Kept the richer 6-field capture (deliberate); payload now carries `Source — Web Form` / `Interest — Website` tag hints + an entry-stage hint.
- **Two new feature pages** completing the §6 mapping: `/features/enquiry-sources` (where hires come from) and `/features/quote-follow-up` (chase every quote). Mechanism links repointed accordingly (source-tracking was unlinked; follow-up was wrongly pointed at Missed Call Text-Back).
- **Parked (not deleted):** `/pricing` and `/lead-generation` (UVH) redirect to `/register-interest` via `next.config.mjs`, excluded from the sitemap; founding-operator sections left unimported. The whole UVH cross-sell layer is parked.
- **Feature page intros** lightly reframed to the growth frame; all primary CTAs → `/register-interest`.
- Removed customer-facing **"contract hire" / "leasing" / "GoHighLevel"**; UK English throughout.

## Verification
- `tsc --noEmit` clean; `npm run build` compiles all routes; sitemap regenerates (parked pages excluded, both new feature pages included).
- Banned-terms + US-spelling greps return zero across live pages.

## Flags / follow-ups (platform-side, not in this repo)
- **No "New Enquiry" pipeline stage exists in GHL** — entry stage is "New Lead" (Marketing Pipeline is the natural home for web interest). The register-interest webhook → workflow (contact creation, tagging, **internal notification**) must be built/confirmed in GHL; the form only POSTs the payload.
- Set **`NEXT_PUBLIC_GHL_WEBHOOK_URL`** in the Vercel/prod env (only present in `.env.local.example`) or the live form errors on submit.
- **Privacy policy:** the three "GoHighLevel" mentions were replaced with "our CRM and communications platform" (keeps GDPR transparency as a category of recipient). Consider a named sub-processor list if legal prefers.
- **Terms & Conditions** still has a "Founding operator pricing" clause — left untouched as legal text; flag for legal if it should be neutralised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
