### PR TITLE
Register-interest opportunities → Nurture Pipeline (idempotent), verified live

### DIFF
--- a/app/api/register-interest/route.ts
+++ b/app/api/register-interest/route.ts
@@ -6,6 +6,7 @@ import {
   upsertContact,
   addContactNote,
   createOpportunity,
+  findOpportunitiesForContact,
   GhlError,
 } from "@/lib/ghl-server";
 
@@ -128,15 +129,28 @@ export async function POST(req: Request) {
   try {
     const target = await resolveTarget();
     if (target) {
-      await createOpportunity({
-        pipelineId: target.pipelineId,
-        pipelineStageId: target.pipelineStageId,
-        name: `Website Interest — ${business || name}`,
-        status: "open",
-        contactId,
-      });
+      // Idempotent: skip if this contact already has an opportunity in the
+      // target pipeline (e.g. on a resubmit) so we never duplicate.
+      let alreadyHas = false;
+      try {
+        const existing = await findOpportunitiesForContact(contactId);
+        alreadyHas = existing.some((o) => o.pipelineId === target.pipelineId);
+      } catch (err) {
+        logError("opportunity dedupe check failed — will attempt create", err);
+      }
+      if (alreadyHas) {
+        console.log(`${LOG} opportunity already exists for contact ${contactId} in pipeline ${target.pipelineId} — skipping`);
+      } else {
+        await createOpportunity({
+          pipelineId: target.pipelineId,
+          pipelineStageId: target.pipelineStageId,
+          name: `Website Interest — ${business || name}`,
+          status: "open",
+          contactId,
+        });
+      }
     } else {
-      // Intentional: tagged contacts only (no nurture pipeline yet). Contact saved.
+      // No pipeline configured — tagged contact only. Contact saved.
       console.log(`${LOG} opportunity disabled — tagged contact saved (contactId ${contactId})`);
     }
   } catch (err) {

--- a/lib/ghl-server.ts
+++ b/lib/ghl-server.ts
@@ -173,3 +173,14 @@ export async function createOpportunity(input: CreateOpportunityInput): Promise<
   });
   return { id: data.opportunity?.id ?? data.id };
 }
+
+export type GhlOpportunity = { id: string; pipelineId?: string; pipelineStageId?: string; status?: string };
+
+/** Existing opportunities for a contact — used to keep opportunity creation
+ *  idempotent (so a resubmit doesn't create a duplicate). */
+export async function findOpportunitiesForContact(contactId: string): Promise<GhlOpportunity[]> {
+  const data = await ghlFetch<{ opportunities?: GhlOpportunity[] }>(
+    `/opportunities/search?location_id=${encodeURIComponent(locationId())}&contact_id=${encodeURIComponent(contactId)}`
+  );
+  return data.opportunities ?? [];
+}

--- a/scripts/ghl-prodsmoke.mjs
+++ b/scripts/ghl-prodsmoke.mjs
@@ -1,0 +1,64 @@
+// PROD SMOKE TEST — POSTs a test enquiry to the LIVE /api/register-interest route
+// (which uses Vercel's GHL_PIT), then verifies the contact in RouleurCo and
+// deletes it. The verify/delete use the LOCAL PIT (.env.local). A dedupe-upsert
+// is used to resolve the contactId reliably (GHL's search index lags).
+//   node --env-file=.env.local scripts/ghl-prodsmoke.mjs
+const APP = process.env.PROD_URL || "https://www.rouleurco.com";
+const BASE = "https://services.leadconnectorhq.com";
+const VERSION = "2021-07-28";
+const ROULEURCO = "hCW1XgNUW2gssImbG9EN";
+const UVH = "kRfviw1Gs30Ek0UF2fYE";
+const TEST_EMAIL = "claude-prodsmoke@test.rouleurco.com";
+
+const pit = process.env.GHL_PIT;
+const loc = process.env.GHL_LOCATION_ID || ROULEURCO;
+if (!pit) { console.error("GHL_PIT not set in .env.local (needed for read-back/delete)"); process.exit(1); }
+if (loc === UVH) { console.error("STOP: UVH location id"); process.exit(1); }
+
+const H = { Authorization: `Bearer ${pit}`, Version: VERSION, Accept: "application/json", "Content-Type": "application/json" };
+async function ghl(method, path, body) {
+  const r = await fetch(BASE + path, { method, headers: H, body: body ? JSON.stringify(body) : undefined });
+  const t = await r.text(); let j; try { j = JSON.parse(t); } catch { j = { raw: t }; }
+  return { ok: r.ok, status: r.status, json: j, text: t };
+}
+
+const payload = {
+  name: "Claude Prodsmoke", email: TEST_EMAIL, business: "Prodsmoke Hire Co",
+  location: "York", fleetSize: "16–30", notes: "Prod smoke test — safe to delete.",
+  consent: true, source: "Website — Register Interest",
+};
+
+(async () => {
+  console.log(`1) POST to LIVE route: ${APP}/api/register-interest`);
+  const res = await fetch(`${APP}/api/register-interest`, {
+    method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload),
+  });
+  const j = await res.json().catch(() => ({}));
+  console.log(`   -> ${res.status} ${JSON.stringify(j)}`);
+  if (res.status !== 200 || !j.ok) { console.error("   FAIL: prod route did not return ok — check Vercel GHL_PIT"); process.exit(1); }
+  console.log("   => prod route upserted the contact in RouleurCo using Vercel's GHL_PIT ✓");
+
+  console.log("\n2) Resolve contactId via dedupe-upsert (local PIT) …");
+  const tags = ["Source — Web Form", "Interest — Website"];
+  if (payload.consent) tags.push("Consent — Email Marketing");
+  const up = await ghl("POST", "/contacts/upsert", {
+    locationId: loc, firstName: payload.name, email: payload.email,
+    companyName: payload.business, city: payload.location, tags, source: payload.source,
+  });
+  const id = up.json.contact?.id ?? up.json.id;
+  console.log(`   upsert ${up.status}  new=${up.json.new} ${up.json.new === false ? "(prod created it first ✓)" : "(WARN created just now)"}  contactId=${id}`);
+
+  console.log("\n3) Read the contact back from RouleurCo …");
+  const full = await ghl("GET", `/contacts/${id}`); const c = full.json.contact || {};
+  console.log(`   locationId : ${c.locationId} ${c.locationId === ROULEURCO ? "✓ RouleurCo" : "✗ NOT RouleurCo"}`);
+  console.log(`   company    : ${c.companyName}`);
+  console.log(`   city       : ${c.city}`);
+  console.log(`   tags       : ${JSON.stringify(c.tags)}`);
+  console.log(`   customFields: ${JSON.stringify(c.customFields)}`);
+
+  console.log("\n4) Delete the test contact …");
+  const del = await ghl("DELETE", `/contacts/${id}`);
+  console.log(`   delete -> ${del.status} ${del.ok ? "✓" : "✗ " + del.text.slice(0, 140)}`);
+
+  console.log("\nPROD SMOKE DONE.");
+})().catch((e) => { console.error("ERROR:", e.message); process.exit(1); });

--- a/scripts/ghl-routetest.mjs
+++ b/scripts/ghl-routetest.mjs
@@ -1,0 +1,104 @@
+// ROUTE TEST — POSTs the form's exact payload to the running /api/register-interest
+// route, then verifies the CONTACT and the OPPORTUNITY (nurture pipeline, entry
+// stage) in RouleurCo, proves dedupe of both on resubmit, and deletes the test
+// contact. Submit goes through the route; verify/cleanup use the local PIT.
+//   1) npm run dev   (server must be running)
+//   2) node --env-file=.env.local scripts/ghl-routetest.mjs
+const APP = process.env.TEST_BASE_URL || "http://localhost:3000";
+const BASE = "https://services.leadconnectorhq.com";
+const VERSION = "2021-07-28";
+const ROULEURCO = "hCW1XgNUW2gssImbG9EN";
+const UVH = "kRfviw1Gs30Ek0UF2fYE";
+const TEST_EMAIL = "claude-routetest@test.rouleurco.com";
+const EXPECT_PIPELINE = process.env.GHL_PIPELINE_ID || "";
+const EXPECT_STAGE = process.env.GHL_PIPELINE_STAGE_ID || "";
+
+const pit = process.env.GHL_PIT;
+const loc = process.env.GHL_LOCATION_ID || ROULEURCO;
+if (!pit) { console.error("GHL_PIT not set"); process.exit(1); }
+if (loc === UVH) { console.error("STOP: UVH location"); process.exit(1); }
+const H = { Authorization: `Bearer ${pit}`, Version: VERSION, Accept: "application/json", "Content-Type": "application/json" };
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+async function ghl(method, path, body) {
+  const r = await fetch(BASE + path, { method, headers: H, body: body ? JSON.stringify(body) : undefined });
+  const t = await r.text(); let j; try { j = JSON.parse(t); } catch { j = { raw: t }; }
+  return { ok: r.ok, status: r.status, json: j, text: t };
+}
+async function opps(contactId) {
+  const r = await ghl("GET", `/opportunities/search?location_id=${loc}&contact_id=${encodeURIComponent(contactId)}`);
+  return r.ok ? (r.json.opportunities || []) : null;
+}
+async function oppsWithRetry(contactId, want = 1, tries = 8) {
+  let last = [];
+  for (let i = 0; i < tries; i++) {
+    const o = await opps(contactId);
+    if (o && o.length >= want) return o;
+    last = o || [];
+    await sleep(4000);
+  }
+  return last;
+}
+
+// Exact payload the form sends (see RegisterInterestForm.tsx).
+const payload = {
+  name: "Claude Routetest", business: "Routetest Hire Co", location: "Hull",
+  fleetSize: "31–50", email: TEST_EMAIL, notes: "Route test — safe to delete.",
+  consent: true, source: "Website — Register Interest",
+};
+
+async function submit() {
+  for (let i = 0; i < 40; i++) {
+    try {
+      const r = await fetch(`${APP}/api/register-interest`, {
+        method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload),
+      });
+      if (r.status !== 404) { const j = await r.json().catch(() => ({})); return { status: r.status, json: j }; }
+    } catch { /* server warming up */ }
+    await sleep(2500);
+  }
+  throw new Error(`dev server never responded at ${APP}`);
+}
+
+(async () => {
+  console.log(`App: ${APP}  Expect pipeline=${EXPECT_PIPELINE} stage=${EXPECT_STAGE}\n`);
+
+  console.log("1) POST #1 to the route …");
+  const s1 = await submit();
+  console.log(`   -> ${s1.status} ${JSON.stringify(s1.json)}`);
+  if (s1.status !== 200 || !s1.json.ok) { console.error("   FAIL: route did not return ok"); process.exit(1); }
+
+  console.log("2) Resolve contactId (dedupe-upsert, local PIT) …");
+  const tags = ["Source — Web Form", "Interest — Website", "Consent — Email Marketing"];
+  const up = await ghl("POST", "/contacts/upsert", { locationId: loc, firstName: payload.name, email: payload.email, companyName: payload.business, city: payload.location, tags, source: payload.source });
+  const id = up.json.contact?.id ?? up.json.id;
+  console.log(`   contactId=${id}  new=${up.json.new} ${up.json.new === false ? "(route created it ✓)" : "(WARN created now)"}`);
+
+  console.log("3) Contact fields …");
+  const c = (await ghl("GET", `/contacts/${id}`)).json.contact || {};
+  console.log(`   locationId=${c.locationId} ${c.locationId === ROULEURCO ? "✓" : "✗"}  company=${c.companyName}  city=${c.city}`);
+  console.log(`   tags=${JSON.stringify(c.tags)}`);
+  console.log(`   custom=${JSON.stringify(c.customFields)}`);
+
+  console.log("4) Opportunity (retrying for search-index lag) …");
+  let o = await oppsWithRetry(id, 1);
+  console.log(`   opportunities found: ${o.length}`);
+  for (const op of o) console.log(`     - ${op.name} | pipeline=${op.pipelineId} ${op.pipelineId === EXPECT_PIPELINE ? "✓" : "✗"} | stage=${op.pipelineStageId} ${op.pipelineStageId === EXPECT_STAGE ? "✓(New Lead)" : "✗"} | status=${op.status}`);
+
+  console.log("\n5) Wait 20s, then POST #2 (resubmit) — dedupe …");
+  await sleep(20000);
+  const s2 = await submit();
+  console.log(`   -> ${s2.status} ${JSON.stringify(s2.json)}`);
+  await sleep(4000);
+  const o2 = await opps(id) || [];
+  const byEmail = (await ghl("GET", `/contacts/?locationId=${loc}&query=${encodeURIComponent(TEST_EMAIL)}`)).json.contacts || [];
+  console.log(`   opportunities now: ${o2.length} ${o2.length === 1 ? "✓ (no duplicate)" : "✗"}`);
+  console.log(`   contacts by email: ${byEmail.length} (search may lag)`);
+
+  console.log("\n6) Delete test contact …");
+  const del = await ghl("DELETE", `/contacts/${id}`);
+  console.log(`   delete -> ${del.status} ${del.ok ? "✓" : "✗"}`);
+  const gone = await ghl("GET", `/contacts/${id}`);
+  console.log(`   re-fetch -> ${gone.status} ${gone.status >= 400 ? "✓ gone" : "✗ still present"}`);
+
+  console.log("\nROUTE TEST DONE.");
+})().catch((e) => { console.error("ERROR:", e.message); process.exit(1); });


### PR DESCRIPTION
Routes register-interest opportunities into the RouleurCo **Nurture Pipeline** and makes opportunity creation idempotent. Verified live against RouleurCo through the actual route.

## What changed
- Opportunities target the **Nurture Pipeline** (`SIIAyli5BrLg3HuS2gE8`) at entry stage **New Lead** (`1fd9d31d-7db4-4f09-8065-dd6edc46323f`) — chosen as the coldest/earliest stage (a website registrant is pure top-of-funnel). Configured via `GHL_PIPELINE_ID` / `GHL_PIPELINE_STAGE_ID` (env, not hardcoded; validated against live RouleurCo pipelines at runtime).
- **Idempotent**: skip opportunity creation if the contact already has one in the target pipeline → no duplicates on resubmit (`findOpportunitiesForContact` in `lib/ghl-server.ts`).
- Verify tooling added (`scripts/ghl-routetest.mjs`, `scripts/ghl-prodsmoke.mjs`).

## Account safety
Read RouleurCo via the RouleurCo PIT (the session `rouleurco-ghl` MCP is UVH-bound). Guard confirmed `locationId = hCW1XgNUW2gssImbG9EN` on every read; nothing UVH touched.

## Verified live (through the route, dev server + .env.local)
- POST → `200 {ok:true}`; contact in RouleurCo: company `Routetest Hire Co`, city `Hull`, Fleet Size `31–50`, tags `Source — Web Form` / `Interest — Website` / `Consent — Email Marketing`.
- **Opportunity** `Website Interest — Routetest Hire Co` created in **Nurture Pipeline / New Lead**, status open ✓
- Resubmit → still **1** opportunity + **1** contact (dedupe both) ✓
- Test contact deleted; its opportunity cascade-removed (Nurture Pipeline back to 0 test records) ✓

## ⚠️ To go live in production (Dan)
Add these to Vercel (Production) on `rouleurco-site`, then redeploy — I don't have access to that Vercel account:
```
GHL_PIPELINE_ID=SIIAyli5BrLg3HuS2gE8
GHL_PIPELINE_STAGE_ID=1fd9d31d-7db4-4f09-8065-dd6edc46323f
```
(Until these are set in Vercel, prod keeps capturing tagged contacts but creates no opportunity — no errors.)

## Override / notes
- **Entry stage** is your call to override — I picked New Lead (coldest). Swap `GHL_PIPELINE_STAGE_ID` if you'd rather a different stage.
- **Real-browser path not automated** (dev server + browser tooling overhead; prod lacks the pipeline vars anyway). I tested the exact request the form sends (read the component, replicated its payload, exercised the route end-to-end), so the on-page form is functionally proven — the one remaining manual check is a single click-through on the live form after the Vercel vars are set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
